### PR TITLE
Improve SEO with robots.txt, sitemap, and meta tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,10 @@
     <title>Reppy | Elite Pull-up Tracking Protocol</title>
     <meta name="title" content="Reppy | Elite Pull-up Tracking Protocol" />
     <meta name="description" content="Dominate the rankings. The tactical tracking platform for pull-up masters. Record reps, visualize gains, and build your inner circle." />
+    <meta name="keywords" content="pull-up tracker, fitness tracker, pullups, calisthenics, workout tracker, gym tracking, reppy, fitness app" />
+    <meta name="robots" content="index, follow" />
+    <meta name="googlebot" content="index, follow" />
+    <link rel="canonical" href="https://reppy.vercel.app/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://reppy.vercel.app/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://reppy.vercel.app/</loc>
+    <lastmod>2024-05-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
This commit introduces key SEO configurations that will help search engines correctly crawl and index the application. Specifically:
- A `robots.txt` in the public folder allows all crawlers and points to the sitemap.
- A basic `sitemap.xml` was added for the main URL (`https://reppy.vercel.app/`).
- Added canonical link and search engine meta tags (`keywords`, `robots`, `googlebot`) to `frontend/index.html`.

---
*PR created automatically by Jules for task [13639138118150678169](https://jules.google.com/task/13639138118150678169) started by @Ro0oman*