### PR TITLE
fix: prevent infinite gem exploit via mission re-claim (#232)

### DIFF
--- a/backend/missions.js
+++ b/backend/missions.js
@@ -75,9 +75,9 @@ router.get('/', authenticate, async (req, res) => {
             ON CONFLICT (user_id, mission_id) DO UPDATE SET
               is_active = true,
               is_completed = false,
-              is_claimed = false,
               current_value = 0,
               last_updated = CURRENT_TIMESTAMP
+            WHERE user_missions.is_claimed = false
           `, [userId, m.id]);
         }
         missionsWereAdded = true;
@@ -88,11 +88,11 @@ router.get('/', authenticate, async (req, res) => {
       // The user only complained about daily. Let's keep special as is or also limit it.
       if (specialActive.length < 1) {
         const newSpecial = await query(`
-          SELECT id FROM missions 
+          SELECT id FROM missions
           WHERE is_daily = false
           AND id NOT IN (
-            SELECT mission_id FROM user_missions 
-            WHERE user_id = $1 AND is_active = true
+            SELECT mission_id FROM user_missions
+            WHERE user_id = $1 AND (is_active = true OR is_claimed = true)
           )
           ORDER BY RANDOM()
           LIMIT 1
@@ -106,9 +106,9 @@ router.get('/', authenticate, async (req, res) => {
             ON CONFLICT (user_id, mission_id) DO UPDATE SET
               is_active = true,
               is_completed = false,
-              is_claimed = false,
               current_value = 0,
               last_updated = CURRENT_TIMESTAMP
+            WHERE user_missions.is_claimed = false
           `, [userId, m.id]);
           missionsWereAdded = true;
         }


### PR DESCRIPTION
## Root cause

`ON CONFLICT (user_id, mission_id) DO UPDATE` in the mission refill logic was unconditionally setting `is_claimed = false`. This meant that if a user navigated away and back on the same day, the refill code could hit the conflict path on an already-claimed mission and reset it to claimable — letting the user collect the reward again.

## Changes

- **`ON CONFLICT DO UPDATE`** for both daily and special missions now includes `WHERE user_missions.is_claimed = false`, so the update is a no-op for already-claimed missions.
- **Special mission candidate query** now excludes missions with `is_claimed = true` (not just `is_active = true`), so a claimed-then-deactivated mission can't be re-inserted as a fresh one.

## Test plan

- [ ] Complete and claim a daily mission → navigate away → return to Missions → verify it shows as claimed and the claim button is gone
- [ ] Complete and claim a special mission → same check
- [ ] Verify new missions are still offered correctly after midnight reset

Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)