### PR TITLE
perf(infra): pin Vercel functions to dub1 (Dublin)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "outputDirectory": "frontend/dist",
+  "regions": ["dub1"],
   "rewrites": [
     { "source": "/api/pusher/auth", "destination": "/api/pusher-auth.js" },
     { "source": "/api/(.*)", "destination": "/api/index.js" },


### PR DESCRIPTION
Part of #234.

## Problem
Vercel functions default to `iad1` (US-East) while Supabase runs in `eu-west-1` (Ireland), so every API DB query crosses the Atlantic. HAR captures of a trivial 23-byte `/api/push/preferences` response showed **280–1060 ms** of wait time (`x-vercel-id: cdg1::iad1::…`) — cross-region hop stacked on serverless cold start. This tax hits every endpoint, independent of any single query.

## Fix
Pin functions to `dub1` (Dublin), adjacent to `eu-west-1`, via `"regions": ["dub1"]` in `vercel.json`. Removes the trans-Atlantic round trip from every request. Takes effect on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
