### PR TITLE
De-uppercase leftover gamer i18n copy (clean/sporty)

### DIFF
--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -188,7 +188,7 @@ export default {
     
     // Social
     active_users: 'ACTIVE OPERATIVES',
-    live_operatives: 'LIVE OPERATIVES',
+    live_operatives: 'Live Operatives',
     boss_raid: 'RAID STATUS',
     find_friends: 'Find Friends',
     search_placeholder: 'Search enthusiasts...',
@@ -343,7 +343,7 @@ export default {
     // Login
     login_title: 'Sign In',
     login_welcome: 'Welcome to Reppy',
-    login_subtitle: 'SYSTEM ACCESS',
+    login_subtitle: 'System access',
     login_password: 'Password',
     login_email: 'Email',
     login_name: 'Full Name',
@@ -524,46 +524,46 @@ export default {
     exercise_mastery_desc: 'HISTORICAL REPOSITORY OF EFFORT BY EXERCISE',
 
     // RPG Stats
-    codex_title: 'THE CODEX',
-    codex_subtitle: 'LEVEL UP GUIDE',
+    codex_title: 'The Codex',
+    codex_subtitle: 'Level up guide',
     codex_next_lv: 'NEXT LEVEL: +100 XP POINTS REQUIRED',
     codex_lv_up: 'Level Up:',
 
-    codex_str_name: 'STRENGTH',
+    codex_str_name: 'Strength',
     codex_str_quote: 'Pure destructive power.',
     codex_str_desc: 'Increases base damage and scaling for heavy exercises like Muscleups and Weighted Pullups.',
     codex_str_action: 'Do weighted exercises or explosive movements.',
 
-    codex_dex_name: 'DEXTERITY',
+    codex_dex_name: 'Dexterity',
     codex_dex_quote: 'Precision over force.',
     codex_dex_desc: 'Increases Critical Hit chance and the damage they deal. Every level significantly boosts your impact against Bosses.',
     codex_dex_action: 'Muscle-ups and Weighted Pull-ups: You gain 10 base XP + extra weight per rep.',
 
-    codex_end_name: 'ENDURANCE',
+    codex_end_name: 'Endurance',
     codex_end_quote: 'The fire that never goes out.',
     codex_end_desc: 'Secondary damage scaling based on total repetition volume. Ideal for high-volume sets.',
     codex_end_action: 'Accumulate more daily reps.',
 
-    codex_vig_name: 'VIGOR',
+    codex_vig_name: 'Vigor',
     codex_vig_quote: 'Iron mind, unbreakable body.',
     codex_vig_desc: 'Increases your resilience and adds stability to your critical hits. Earned through training streaks.',
     codex_vig_action: 'Keep your daily streak alive.',
 
-    codex_int_name: 'INTELLIGENCE',
+    codex_int_name: 'Intelligence',
     codex_int_quote: 'Knowledge is the ultimate gains.',
     codex_int_desc: 'Training efficiency. Grants a global XP bonus (+5% per level) to all training stats. Earned by reading tactical guides.',
     codex_int_action: 'Read tactical guides in the blog to level up Intelligence.',
 
-    codex_fth_name: 'FAITH',
+    codex_fth_name: 'Faith',
     codex_fth_quote: 'The bar provides, the iron judge.',
     codex_fth_desc: 'Divine damage and community aura. Increases your Holy damage multiplier and provides extra flat damage bonuses.',
     codex_fth_action: 'Participate in Boss Battles. Every 50 damage dealt grants 1 XP.',
-    codex_cha_name: 'CHARISMA',
+    codex_cha_name: 'Charisma',
     codex_cha_quote: 'Your aura precedes you.',
     codex_cha_desc: 'Social impact and damage multiplier. Earned by interacting with the community.',
     codex_cha_action: 'Like or comment on posts in the social feed.',
     blog_xp_gained: 'Knowledge acquired! +100 INT XP earned.',
-    intelecto_adquirido: 'KNOWLEDGE ACQUIRED',
+    intelecto_adquirido: 'Knowledge acquired',
     blog_read_congrats: 'Guide complete: Intellect increased.',
 
     // Post Backgrounds
@@ -799,17 +799,17 @@ export default {
     active_yield_desc: 'ACTIVE OPERATIVES YIELD',
 
     // Social & Community
-    community: 'COMMUNITY',
-    community_subtitle: 'SYNCHRONIZE WITH THE CORE ELITE.',
+    community: 'Community',
+    community_subtitle: 'See what people are training and join in.',
     social_wall: 'SOCIAL WALL',
-    rankings: 'RANKINGS',
+    rankings: 'Rankings',
     global_rankings: 'GLOBAL.RANKINGS',
     find_athletes: 'FIND_OPERATIVES',
-    inner_circle: 'INNER_CIRCLE',
+    inner_circle: 'My Inner Circle',
     reps_collected: 'REPS COLLECTED',
     reps_scaled: 'REPS SCALED',
     protocol_label: 'Registry',
-    live_sync: 'LIVE RANKING SYNCHRONIZATION',
+    live_sync: 'Live sync',
     friend_added: 'Friend added successfully!',
     friend_add_failed: 'Failed to add friend',
 
@@ -975,7 +975,7 @@ export default {
     // Activity Card
     activity_level_label: 'LVL',
     activity_reps_session: 'REPS',
-    activity_damage_session: 'DAMAGE',
+    activity_damage_session: 'Damage',
     activity_milestone_msg: '{threshold} total {exercise}!',
     activity_personal_record: 'PERSONAL RECORD',
     activity_rank_top: 'RANK #{n} GLOBAL',

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -197,7 +197,7 @@ export default {
     
     // Social
     active_users: 'OPERATIVOS ACTIVOS',
-    live_operatives: 'OPERATIVOS EN DIRECTO',
+    live_operatives: 'Operativos en directo',
     boss_raid: 'ESTADO DE RAID',
     find_friends: 'Buscar Amigos',
     search_placeholder: 'Buscar entusiastas...',
@@ -356,7 +356,7 @@ export default {
     // Login
     login_title: 'Iniciar Sesión',
     login_welcome: 'Bienvenido a Reppy',
-    login_subtitle: 'ACCESO AL SISTEMA',
+    login_subtitle: 'Acceso al sistema',
     login_password: 'Contraseña',
     login_email: 'Email',
     login_name: 'Nombre completo',
@@ -543,8 +543,8 @@ export default {
     exercise_mastery_desc: 'REPOSITORIO HISTÓRICO DE MAGNITUD POR EJERCICIO',
 
     // Codex
-    codex_title: 'EL CODEX',
-    codex_subtitle: 'GUÍA PARA SUBIR DE NIVEL',
+    codex_title: 'El Códex',
+    codex_subtitle: 'Guía para subir de nivel',
     codex_next_lv: 'PRÓXIMO NIVEL: +100 XP REQUERIDOS',
     codex_lv_up: 'Mejora:',
 
@@ -577,7 +577,7 @@ export default {
     codex_cha_action: 'Da like o comenta en las publicaciones del feed social.',
     
     blog_xp_gained: '¡Conocimiento adquirido! +100 XP de INT ganada.',
-    intelecto_adquirido: 'INTELECTO ADQUIRIDO',
+    intelecto_adquirido: 'Intelecto adquirido',
     blog_read_congrats: 'Estudio completado: Intelecto aumentado.',
 
     // Post Backgrounds
@@ -837,7 +837,7 @@ export default {
     boss_anomaly: 'ANOMALÍAS DE BOSS',
     monthly_projection: 'PROYECCIÓN MENSUAL',
     active_yield_desc: 'RENDIMIENTO OPERATIVO ACTIVO',
-    feat_heatmap_title: 'MAPA DE CALOR DE DISTRIBUCIÓN',
+    feat_heatmap_title: 'Heatmap táctico',
     stats_active_days: 'Activo 365 Días',
 
     // Social & Community
@@ -1025,7 +1025,7 @@ export default {
     // Activity Card
     activity_level_label: 'LVL',
     activity_reps_session: 'REPS',
-    activity_damage_session: 'DAÑO',
+    activity_damage_session: 'Daño',
     activity_personal_record: 'RÉCORD PERSONAL',
     activity_rank_top: 'RANK #{n} GLOBAL',
     activity_top_dated: 'TOP {n}% ({date})',


### PR DESCRIPTION
Cierra #252. Seguimiento de #249/#250.

Tras el dedup, el valor renderizado de varias keys era la vieja cadena gamer en MAYÚSCULAS (la variante limpia era el duplicado eliminado). Las sustituyo por copy en caja normal, alineada con la marca clean/sporty.

**Grupo A (casing, EN):** codex stat names (STRENGTH→Strength…), community, rankings, live_operatives, inner_circle, codex_title/subtitle. En `Codex.vue` los stat names no fuerzan uppercase por CSS, así que EN ahora coincide con ES ('Fuerza'…).

**Grupo B (revisado por uso):** login_subtitle (label corto), live_sync, community_subtitle, intelecto_adquirido, feat_heatmap_title (ES→'Heatmap táctico', coincide con EN 'Tactical Heatmap'), activity_damage_session.

**Mantenido a propósito:** `ui_pb`='PB' — badge diminuto junto a un trofeo en ActivityCard, la abreviatura es intencional.

25 sustituciones puras (25+/25-). Guard de duplicados en verde, ambos locales cargan.