### PR TITLE
Dashboard redesign — Momentum (day ring + log sheet)

### DIFF
--- a/frontend/src/components/pages/Dashboard.vue
+++ b/frontend/src/components/pages/Dashboard.vue
@@ -28,37 +28,58 @@
       </div>
     </header>
 
-    <!-- The Hero: pick exercise → log (kept together, all breakpoints) -->
+    <!-- The Hero (Momentum): pick exercise → see today's ring → log -->
     <section
       v-if="!trainingStore.todayWorkout || showFreeLog"
-      class="max-w-3xl mx-auto w-full space-y-3"
+      class="max-w-md mx-auto w-full space-y-4"
     >
       <ExerciseSelector v-model="activeExercise" compact class="w-full" />
-      <div
-        ref="repsInputSection"
-        class="transition-all duration-500 rounded-2xl"
-        :class="highlightRepsInput ? 'ring-2 ring-primary-500/60 shadow-[0_0_30px_hsl(var(--primary)/0.25)]' : ''"
-      >
-        <div v-if="activeExercise === 'all'" class="bg-surface/5 border border-dashed border-border rounded-2xl flex flex-col items-center justify-center text-center p-8 sm:p-10">
-          <Globe aria-hidden="true" class="w-10 h-10 text-muted/50 mb-3" />
-          <h3 class="text-lg font-bold tracking-tight text-foreground">
-            {{ i18n.t('dash_overview_mode') }}
-          </h3>
-          <p class="text-xs text-muted/60 max-w-[320px] mx-auto mt-1.5">
-            {{ i18n.t('dash_overview_hint') }}
-          </p>
-          <div class="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-2 w-full max-w-md">
-            <button
-              v-for="option in quickLogOptions"
-              :key="option.id"
-              @click="activeExercise = option.id"
-              class="h-10 rounded-xl border border-border bg-foreground/[0.03] hover:bg-primary-500/10 hover:border-primary-500/30 text-xs font-semibold text-foreground/90 transition-all active:scale-[0.98]"
-            >
-              {{ option.label }}
-            </button>
-          </div>
+
+      <!-- Overview mode: no single exercise picked yet -->
+      <div v-if="activeExercise === 'all'" class="bg-surface/5 border border-dashed border-border rounded-2xl flex flex-col items-center justify-center text-center p-8 sm:p-10">
+        <Globe aria-hidden="true" class="w-10 h-10 text-muted/50 mb-3" />
+        <h3 class="text-lg font-bold tracking-tight text-foreground">
+          {{ i18n.t('dash_overview_mode') }}
+        </h3>
+        <p class="text-xs text-muted/60 max-w-[320px] mx-auto mt-1.5">
+          {{ i18n.t('dash_overview_hint') }}
+        </p>
+        <div class="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-2 w-full max-w-md">
+          <button
+            v-for="option in quickLogOptions"
+            :key="option.id"
+            @click="activeExercise = option.id"
+            class="h-10 rounded-xl border border-border bg-foreground/[0.03] hover:bg-primary-500/10 hover:border-primary-500/30 text-xs font-semibold text-foreground/90 transition-all active:scale-[0.98]"
+          >
+            {{ option.label }}
+          </button>
         </div>
-        <RepsInput v-else :exercise-type="activeExercise" @updated="fetchData" class="w-full" />
+      </div>
+
+      <!-- Day ring + log CTA -->
+      <div
+        v-else
+        ref="repsInputSection"
+        class="flex flex-col items-center transition-all duration-500 rounded-3xl"
+        :class="highlightRepsInput ? 'ring-2 ring-primary-500/60' : ''"
+      >
+        <RadialProgress :progress="dayRingPercent" :size="208" :stroke-width="14">
+          <div class="flex flex-col items-center">
+            <span class="text-[2.75rem] font-bold tabular-nums leading-none text-foreground">{{ todayProgress }}</span>
+            <span class="mt-2 text-xs text-muted/60">
+              {{ i18n.t('dash_ring_of') }} {{ stats.dailyGoal }} · {{ activeExerciseLabel }}
+            </span>
+          </div>
+        </RadialProgress>
+
+        <button
+          type="button"
+          @click="openLogSheet"
+          class="mt-5 w-full max-w-xs flex items-center justify-center gap-2 rounded-2xl bg-primary-500 hover:bg-primary-400 active:bg-primary-600 px-5 py-3.5 text-base font-semibold text-white transition-all active:scale-[0.98] shadow-lg shadow-primary-500/20"
+        >
+          <Plus aria-hidden="true" class="w-5 h-5" />
+          {{ i18n.t('dash_log_reps_cta') }}
+        </button>
       </div>
     </section>
 
@@ -288,20 +309,20 @@
       </div>
     </section>
 
-    <!-- Mobile toggle: show advanced stats on demand -->
-    <div class="lg:hidden">
+    <!-- Disclosure: heavy progress + boss section, collapsed by default (Momentum: home stays light) -->
+    <div>
       <button
         @click="showAdvancedStats = !showAdvancedStats"
         class="w-full flex items-center justify-center gap-2 py-3 rounded-2xl border border-border/60 bg-foreground/[0.02] hover:bg-foreground/[0.05] text-sm font-semibold text-muted hover:text-foreground transition-all active:scale-[0.98]"
       >
         <BarChart3 aria-hidden="true" class="w-4 h-4" />
-        {{ showAdvancedStats ? i18n.t('dash_stats_hide') : i18n.t('dash_stats_show') }}
+        {{ showAdvancedStats ? i18n.t('dash_stats_hide') : i18n.t('dash_stats_boss_toggle') }}
         <ChevronDown aria-hidden="true" class="w-4 h-4 transition-transform duration-200" :class="showAdvancedStats ? 'rotate-180' : ''" />
       </button>
     </div>
 
-    <!-- Stats & boss (hidden on mobile until toggled) -->
-    <section v-show="showAdvancedStats || isDesktop" class="grid grid-cols-1 lg:grid-cols-3 gap-5 items-start">
+    <!-- Stats & boss (collapsed until toggled, all breakpoints) -->
+    <section v-show="showAdvancedStats" class="grid grid-cols-1 lg:grid-cols-3 gap-5 items-start">
       <!-- Boss Intel -->
       <div class="lg:col-span-2 space-y-4">
         <div class="flex items-center gap-2 px-1">
@@ -390,8 +411,8 @@
       </div>
     </section>
 
-    <!-- Analytics: activity heatmap / history (follows mobile toggle) -->
-    <section v-show="showAdvancedStats || isDesktop" class="space-y-4">
+    <!-- Analytics: activity heatmap / history (follows disclosure) -->
+    <section v-show="showAdvancedStats" class="space-y-4">
       <div class="flex items-center gap-1 p-1 bg-foreground/[0.04] border border-border/60 rounded-xl w-fit mx-auto">
         <button
           @click="activeTab = 'heatmap'"
@@ -508,6 +529,12 @@
       @selected="handleGuidedPlanSelected"
     />
     <WeeklyShareCard :open="showWeeklyCard" @close="showWeeklyCard = false" />
+    <LogSheet
+      :open="showLogSheet"
+      :exercise-type="activeExercise"
+      @close="showLogSheet = false"
+      @updated="fetchData"
+    />
   </div>
 </template>
 
@@ -517,14 +544,15 @@ import { useRoute, useRouter } from 'vue-router';
 import axios from 'axios';
 import {
   Trophy, Target, Flame, Zap, Activity, Inbox,
-  BarChart3, Check, X, Trash2, Globe, Sword, FlaskConical, Coins, Snowflake, ChevronDown, Share2, Pencil
+  BarChart3, Check, X, Trash2, Globe, Sword, FlaskConical, Coins, Snowflake, ChevronDown, Share2, Pencil, Plus
 } from 'lucide-vue-next';
 import { useAuthStore } from '@/stores/auth';
 import { useI18nStore } from '@/stores/i18n';
 import { useNotificationStore } from '@/stores/notification';
 import { useTrainingStore } from '@/stores/training';
 import Heatmap from '@/components/training/Heatmap.vue';
-import RepsInput from '@/components/training/RepsInput.vue';
+import RadialProgress from '@/components/ui/RadialProgress.vue';
+import LogSheet from '@/components/training/LogSheet.vue';
 import ExerciseSelector from '@/components/training/ExerciseSelector.vue';
 import BossHealth from '@/components/boss/BossHealth.vue';
 import RPGReleaseModal from '@/components/modals/RPGReleaseModal.vue';
@@ -557,12 +585,9 @@ const showRPGModal = ref(false);
 const showQuickStartModal = ref(false);
 const showGoalOnboarding = ref(false);
 const showFreeLog = ref(false);
+const showLogSheet = ref(false);
 const activeTab = ref('heatmap');
 const showAdvancedStats = ref(false);
-// Reactive desktop breakpoint: kept in sync with viewport via matchMedia (see onMounted/onUnmounted).
-const isDesktop = ref(typeof window !== 'undefined' && window.matchMedia('(min-width: 1024px)').matches);
-let desktopMql = null;
-const handleDesktopChange = (e) => { isDesktop.value = e.matches; };
 const unclaimedMissions = ref(0);
 const highlightRepsInput = ref(false);
 const repsInputSection = ref(null);
@@ -760,17 +785,22 @@ const freezeStreak = async () => {
   }
 };
 
-const scrollToRepsInput = async () => {
+// Opens the log sheet (Momentum's primary gesture). Ensures a concrete exercise
+// is selected first, briefly highlights the ring, and surfaces it into view.
+const openLogSheet = async () => {
   if (activeExercise.value === 'all') {
     activeExercise.value = 'pullups';
   }
+  showFreeLog.value = true;
   await nextTick();
   repsInputSection.value?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   highlightRepsInput.value = true;
-  setTimeout(() => {
-    highlightRepsInput.value = false;
-  }, 1500);
+  setTimeout(() => { highlightRepsInput.value = false; }, 1200);
+  showLogSheet.value = true;
 };
+
+// Back-compat: existing callers (empty states, ?log=1 intent) now open the sheet.
+const scrollToRepsInput = openLogSheet;
 
 const handleCloseQuickStartModal = () => {
   markQuickStartSeen();
@@ -833,6 +863,12 @@ const todayProgress = computed(() => {
   return reps.value
     .filter(r => getLocalDateString(r.date) === today)
     .reduce((acc, curr) => acc + Number(curr.count), 0);
+});
+
+// Day ring fill: today's reps for the selected exercise vs the daily goal.
+const dayRingPercent = computed(() => {
+  const goal = Math.max(1, Number(stats.dailyGoal) || 0);
+  return Math.min(100, Math.round((todayProgress.value / goal) * 100));
 });
 
 const isDailyObjectiveDone = computed(() => {
@@ -1217,18 +1253,10 @@ onMounted(async () => {
   timerInterval = setInterval(() => {
     currentTime.value = new Date();
   }, 1000);
-
-  // Keep isDesktop in sync with the viewport (drives the mobile stats toggle).
-  if (typeof window !== 'undefined') {
-    desktopMql = window.matchMedia('(min-width: 1024px)');
-    isDesktop.value = desktopMql.matches;
-    desktopMql.addEventListener('change', handleDesktopChange);
-  }
 });
 
 onUnmounted(() => {
   if (timerInterval) clearInterval(timerInterval);
-  if (desktopMql) desktopMql.removeEventListener('change', handleDesktopChange);
 });
 
 watch(

--- a/frontend/src/components/training/LogSheet.vue
+++ b/frontend/src/components/training/LogSheet.vue
@@ -1,0 +1,76 @@
+<template>
+  <Teleport to="body">
+    <Transition name="logsheet">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-[80] flex items-end sm:items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        @click.self="$emit('close')"
+      >
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/60" @click="$emit('close')" />
+
+        <!-- Sheet -->
+        <div class="logsheet-panel relative z-10 w-full sm:max-w-md bg-surface border-t sm:border border-border rounded-t-3xl sm:rounded-2xl px-4 pt-3 pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:p-5">
+          <!-- Grabber + close -->
+          <div class="flex items-center justify-between mb-3">
+            <div class="flex-1 flex justify-center sm:hidden">
+              <span class="h-1 w-10 rounded-full bg-foreground/15"></span>
+            </div>
+            <button
+              type="button"
+              class="grid h-8 w-8 place-items-center rounded-xl text-muted hover:text-foreground hover:bg-foreground/[0.06] transition-colors sm:ml-auto"
+              :aria-label="i18n.t('dash_close') || 'Close'"
+              @click="$emit('close')"
+            >
+              <X class="w-4 h-4" />
+            </button>
+          </div>
+
+          <RepsInput :exercise-type="exerciseType" @updated="handleUpdated" />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { watch } from 'vue';
+import { X } from 'lucide-vue-next';
+import { useI18nStore } from '@/stores/i18n';
+import RepsInput from '@/components/training/RepsInput.vue';
+
+const i18n = useI18nStore();
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  exerciseType: { type: String, default: 'pullups' },
+});
+const emit = defineEmits(['close', 'updated']);
+
+// Lock body scroll while the sheet is open.
+watch(() => props.open, (isOpen) => {
+  if (typeof document === 'undefined') return;
+  document.body.style.overflow = isOpen ? 'hidden' : '';
+}, { immediate: true });
+
+const handleUpdated = () => {
+  emit('updated');
+  emit('close');
+};
+</script>
+
+<style scoped>
+.logsheet-enter-active,
+.logsheet-leave-active { transition: opacity 0.25s ease; }
+.logsheet-enter-from,
+.logsheet-leave-to { opacity: 0; }
+.logsheet-enter-active .logsheet-panel,
+.logsheet-leave-active .logsheet-panel { transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1); }
+.logsheet-enter-from .logsheet-panel,
+.logsheet-leave-to .logsheet-panel { transform: translateY(100%); }
+@media (min-width: 640px) {
+  .logsheet-enter-from .logsheet-panel,
+  .logsheet-leave-to .logsheet-panel { transform: translateY(12px) scale(0.98); }
+}
+</style>

--- a/frontend/src/components/ui/RadialProgress.vue
+++ b/frontend/src/components/ui/RadialProgress.vue
@@ -1,41 +1,34 @@
 <template>
   <div class="relative flex items-center justify-center" :style="{ width: size + 'px', height: size + 'px' }">
-    <svg :width="size" :height="size" class="transform -rotate-90 drop-shadow-xl">
-      <!-- Background Circle -->
+    <svg :width="size" :height="size" class="-rotate-90">
+      <!-- Track -->
       <circle
         :cx="size / 2"
         :cy="size / 2"
         :r="radius"
+        :stroke-width="strokeWidth"
         stroke="currentColor"
-        stroke-width="12"
         fill="transparent"
-        class="text-foreground/5"
+        class="text-foreground/10"
       />
-      <!-- Progress Circle -->
+      <!-- Progress -->
       <circle
         :cx="size / 2"
         :cy="size / 2"
         :r="radius"
-        stroke="url(#progressGradient)"
-        stroke-width="12"
+        :stroke-width="strokeWidth"
+        :stroke="isComplete ? 'hsl(var(--accent))' : 'hsl(var(--primary))'"
         fill="transparent"
         stroke-linecap="round"
         :stroke-dasharray="circumference"
         :stroke-dashoffset="dashoffset"
-        class="transition-all duration-1000 ease-out filter drop-shadow-[0_0_8px_hsl(var(--primary) / 0.3)]"
+        class="transition-all duration-700 ease-out"
       />
-      <!-- Gradient Definition -->
-      <defs>
-        <linearGradient id="progressGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stop-color="#FF4500" />
-          <stop offset="100%" stop-color="#CCFF00" />
-        </linearGradient>
-      </defs>
     </svg>
-    <!-- Center Label -->
+    <!-- Center content -->
     <div class="absolute inset-0 flex flex-col items-center justify-center text-center">
       <slot>
-        <span class="text-2xl font-black text-industrial text-foreground">{{ Math.round(progress) }}%</span>
+        <span class="text-2xl font-bold tabular-nums text-foreground">{{ Math.round(clampedProgress) }}%</span>
       </slot>
     </div>
   </div>
@@ -45,26 +38,15 @@
 import { computed } from 'vue';
 
 const props = defineProps({
-  progress: {
-    type: Number,
-    default: 0
-  },
-  size: {
-    type: Number,
-    default: 160
-  }
+  // 0–100
+  progress: { type: Number, default: 0 },
+  size: { type: Number, default: 160 },
+  strokeWidth: { type: Number, default: 12 },
 });
 
-const radius = computed(() => (props.size / 2) - 10);
+const clampedProgress = computed(() => Math.min(Math.max(props.progress, 0), 100));
+const isComplete = computed(() => clampedProgress.value >= 100);
+const radius = computed(() => (props.size / 2) - props.strokeWidth);
 const circumference = computed(() => 2 * Math.PI * radius.value);
-const dashoffset = computed(() => {
-  const p = Math.min(Math.max(props.progress, 0), 100);
-  return circumference.value - (p / 100) * circumference.value;
-});
+const dashoffset = computed(() => circumference.value - (clampedProgress.value / 100) * circumference.value);
 </script>
-
-<style scoped>
-.text-industrial {
-  font-family: 'Inter Tight', sans-serif;
-}
-</style>

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1184,6 +1184,9 @@ export default {
      notif_push_never: 'No, never',
 
     // ── Dashboard ──────────────────────────────────────────────
+    dash_close: 'Close',
+    dash_ring_of: 'of',
+    dash_stats_boss_toggle: 'Progress & boss',
     dash_my_week: 'My week',
     dash_guided_plan: 'Guided plan',
     dash_overview_mode: 'Overview mode',

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -1263,6 +1263,9 @@ export default {
      ex_chest: 'Pecho',
 
     // ── Dashboard ──────────────────────────────────────────────
+    dash_close: 'Cerrar',
+    dash_ring_of: 'de',
+    dash_stats_boss_toggle: 'Ver progreso y boss',
     dash_my_week: 'Mi semana',
     dash_guided_plan: 'Plan guiado',
     dash_overview_mode: 'Modo resumen',


### PR DESCRIPTION
Rediseño **completo** del dashboard (Refs #238). Dirección elegida: **Momentum** (sobre Arena/Field), tras maquetar tres conceptos.

La home pasa a tener un solo trabajo: **elegir ejercicio → ver el anillo de hoy → registrar.**

## Cambios
- **Nuevo héroe:** `ExerciseSelector` + anillo de progreso del día (reps de hoy vs objetivo diario, por ejercicio) + un único CTA **Registrar reps**.
- **Nuevo `LogSheet.vue`:** bottom-sheet que envuelve `RepsInput` (stepper, presets, chip de daño), abierto por el CTA. Sustituye al `RepsInput` siempre-inline.
- **`ui/RadialProgress.vue` reescrito:** estaba sin usar y con el estilo gamer viejo (gradiente naranja→lima + glow + `font-black`). Ahora es un anillo flat de marca: azul primario, esmeralda al 100%, centro por slot, sin gradiente/glow.
- **Sección pesada colapsada por defecto** en todos los breakpoints (BossHealth, LivePresence, Combat Power, totales, heatmap, historial) tras un disclosure "Progreso y boss". No se elimina nada; la home queda ligera y el boss está a un tap.
- Eliminado el `isDesktop`/matchMedia ya muerto (no gateaba nada).
- Keys i18n nuevas: `dash_close`, `dash_ring_of`, `dash_stats_boss_toggle`.

## Verificación
- Los 3 SFC compilan (Vite transform 200).
- Guard de i18n en verde.
- **Pendiente (tu sesión logueada):** valores del anillo con datos reales, abrir/cerrar la hoja y registrar, estado al 100%, y el flujo de plan guiado (`showFreeLog`).

## Notas de diseño
Esto es Fase 1 (home + gesto de registro). Fase 2/3 (mover boss y stats a vistas propias en lugar del disclosure, fila slim de boss con HP en vivo) quedan como seguimiento si validas la dirección.