### PR TITLE
fix(dashboard): no recargar misiones/plan/racha al cambiar de ejercicio

### DIFF
--- a/frontend/src/components/pages/Dashboard.vue
+++ b/frontend/src/components/pages/Dashboard.vue
@@ -972,20 +972,18 @@ const fetchGlobalData = async () => {
   }
 };
 
-const fetchData = async () => {
+// Exercise-scoped data only: reps history, heatmap and stats for the selected
+// exercise. This is the ONLY thing that changes when you switch exercise — it
+// must NOT touch missions, the guided plan or the streak (they're global).
+const fetchExerciseData = async () => {
   isLoading.value = true;
-  guidedTrainingStateLoaded.value = false;
   try {
-    const params = { 
-      type: activeExercise.value,
-      year: activeYear.value 
-    };
+    const params = { type: activeExercise.value, year: activeYear.value };
     const t = Date.now();
     const [repsRes, heatmapRes, statsRes] = await Promise.all([
       axios.get('/api/reps', { params: { ...params, t } }),
       axios.get('/api/reps/heatmap', { params: { ...params, t } }),
       axios.get('/api/reps/stats', { params: { ...params, t } }),
-      fetchStreakStatus()
     ]);
 
     reps.value = repsRes.data;
@@ -995,7 +993,21 @@ const fetchData = async () => {
     stats.dailyGoal = statsRes.data.dailyGoal || 50;
     stats.totalVolume = statsRes.data.totalVolume || 0;
     stats.combatPower = statsRes.data.combatPower || { total: 0, base: 0, gear: 0, buff: 0 };
+    return statsRes;
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+// Full refresh: exercise data + global state (streak, missions, guided plan,
+// boss) + first-run onboarding. Use on mount and after a mutation that changes
+// global state (logging reps, editing/deleting entries) — NOT on exercise switch.
+const fetchData = async () => {
+  guidedTrainingStateLoaded.value = false;
+  try {
+    const statsRes = await fetchExerciseData();
     await Promise.all([
+      fetchStreakStatus(),
       fetchGlobalData(),
       trainingStore.fetchMine()
     ]);
@@ -1023,8 +1035,6 @@ const fetchData = async () => {
   } catch (error) {
     console.error('Error fetching data:', error);
     guidedTrainingStateLoaded.value = true;
-  } finally {
-    isLoading.value = false;
   }
 };
 
@@ -1052,9 +1062,10 @@ const saveEdit = async (id) => {
   }
 };
 
-// Update data when exercise type changes
+// Switching exercise only refetches exercise-scoped data — missions, the guided
+// plan and the streak stay put (they don't depend on the selected exercise).
 watch(activeExercise, () => {
-  fetchData();
+  fetchExerciseData();
 });
 
 watch(


### PR DESCRIPTION
## Bug
Cambiar de ejercicio disparaba `fetchData()` completo, que re-pedía misiones (`fetchGlobalData`), el plan guiado (`trainingStore.fetchMine`) y la racha, y reseteaba `guidedTrainingStateLoaded` → la tarjeta de **Misión de hoy** parpadeaba/recargaba en cada cambio de ejercicio. Ninguno de esos datos depende del ejercicio seleccionado.

## Fix
Separo en dos funciones:
- `fetchExerciseData()` — solo reps + heatmap + stats (lo único que depende del ejercicio).
- `fetchData()` — datos de ejercicio + racha + misiones + plan + onboarding.

El `watch(activeExercise)` ahora llama solo a `fetchExerciseData()`. `fetchData()` se mantiene en el montaje y tras mutaciones (registrar, editar, borrar) donde sí cambia el estado global.

Preexistente en `main` (no lo introdujo el rediseño Momentum). Compila (Vite transform 200).