### PR TITLE
feat(battle): efectos de pociones activas en la batalla

### DIFF
--- a/frontend/src/components/battle/BattleActiveBuffs.vue
+++ b/frontend/src/components/battle/BattleActiveBuffs.vue
@@ -1,0 +1,37 @@
+<template>
+  <!-- Compact strip of currently-active potion buffs, with live countdown.
+       Only renders when at least one buff is active. -->
+  <div v-if="buffs.length" class="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.07] p-2.5 backdrop-blur-sm">
+    <div class="mb-1.5 flex items-center gap-1.5 px-0.5">
+      <Sparkles class="h-3.5 w-3.5 text-emerald-400" />
+      <span class="text-[10px] font-black uppercase tracking-[0.2em] text-emerald-300/80">{{ i18n.t('dash_active_effects') }}</span>
+    </div>
+    <div class="flex flex-wrap gap-1.5">
+      <span v-for="b in buffs" :key="b.type"
+        class="flex items-center gap-1.5 rounded-lg border border-emerald-500/25 bg-black/30 px-2 py-1">
+        <FlaskConical class="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+        <span class="text-[10px] font-bold text-emerald-200">{{ b.label }}</span>
+        <span class="text-[10px] font-black text-emerald-300">{{ b.value }}</span>
+        <span class="font-mono text-[10px] tabular-nums text-white/45">{{ b.timeLeft }}</span>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { Sparkles, FlaskConical } from 'lucide-vue-next';
+import { useAuthStore } from '@/stores/auth';
+import { useI18nStore } from '@/stores/i18n';
+import { buildActiveBoosts } from '@/utils/activeBuffs';
+
+const authStore = useAuthStore();
+const i18n = useI18nStore();
+const now = ref(new Date());
+let timer = null;
+
+const buffs = computed(() => buildActiveBoosts(authStore.user, now.value, i18n));
+
+onMounted(() => { timer = setInterval(() => { now.value = new Date(); }, 1000); });
+onUnmounted(() => { if (timer) clearInterval(timer); });
+</script>

--- a/frontend/src/components/pages/BattleView.vue
+++ b/frontend/src/components/pages/BattleView.vue
@@ -29,8 +29,9 @@
             @show-live="liveRef?.open()" />
         </div>
 
-        <!-- Right: controls (potions + register reps) -->
+        <!-- Right: controls (active buffs + potions + register reps) -->
         <div class="space-y-1.5 lg:space-y-3">
+          <BattleActiveBuffs />
           <QuickPotions @activated="onPotionActivated" />
           <BattleRepsPanel :loading="logging" :streak="streak" @train="onTrain" />
         </div>
@@ -49,6 +50,7 @@ import RpgTopBar from '@/components/battle/RpgTopBar.vue';
 import PlayerCard from '@/components/battle/PlayerCard.vue';
 import BossArena from '@/components/battle/BossArena.vue';
 import QuickPotions from '@/components/battle/QuickPotions.vue';
+import BattleActiveBuffs from '@/components/battle/BattleActiveBuffs.vue';
 import BattleRepsPanel from '@/components/battle/BattleRepsPanel.vue';
 import LivePresence from '@/components/ui/LivePresence.vue';
 import { useBossStore } from '@/stores/boss';


### PR DESCRIPTION
Continuación de #295 (ya mergeado). Este commit quedó fuera del merge.

## Cambio
Muestra los **efectos de pociones activas** en la vista de batalla:
- Nuevo `BattleActiveBuffs.vue`: tira compacta con los buffs activos (multiplicador de daño + bonus de stats) y **cuenta atrás en vivo**.
- Reutiliza `buildActiveBoosts()` de `utils/activeBuffs` (misma fuente que Dashboard/Inventario, sin duplicar lógica).
- Se muestra en la columna de controles, encima de ACCESO RÁPIDO; solo aparece si hay algún buff activo.

Verificado en preview: muestra "Aumento de Destreza +2 · 00:27:53" y "Aumento de Resistencia +7 · 00:57:55" con temporizadores corriendo. Sin errores de consola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)