### PR TITLE
fix(security): disable /api/test/* cheat endpoints in production

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -30,7 +30,7 @@ import adminRoutes from './admin.js';
 import blogRoutes from './blog.js';
 import pvpRoutes from './pvp.js';
 import challengeRoutes from './async_challenges.js';
-import testRoutes from './test.js';
+import testRoutes, { testEndpointsEnabled } from './test.js';
 import missionsRoutes from './missions.js';
 import pushRoutes from './push.js';
 import trainingRoutes from './training.js';
@@ -154,7 +154,16 @@ apiRouter.use('/admin', adminRoutes);
 apiRouter.use('/blog-tracking', blogRoutes);
 apiRouter.use('/pvp', pvpRoutes);
 apiRouter.use('/challenges', challengeRoutes);
-apiRouter.use('/test', testRoutes);
+// Test/E2E-only endpoints (coins/gems/items/stats cheats). Mounted only when
+// explicitly enabled — see testEndpointsEnabled in test.js. In production they
+// are absent entirely. NOTE: the presence `/test/ping` handler below is
+// defined directly on apiRouter and is intentionally always available.
+if (testEndpointsEnabled) {
+  apiRouter.use('/test', testRoutes);
+  console.log('[BOOT] Test/E2E endpoints ENABLED under /test (non-production).');
+} else {
+  console.log('[BOOT] Test/E2E endpoints disabled (production).');
+}
 apiRouter.use('/missions', missionsRoutes);
 apiRouter.use('/push', pushRoutes);
 apiRouter.use('/training', trainingRoutes);

--- a/backend/test.js
+++ b/backend/test.js
@@ -5,12 +5,23 @@ import { recalculateUserStats } from './utils/stats.js';
 
 const router = express.Router();
 
-// ALWAYS ALLOW FOR PLAYWRIGHT E2E TESTING
-const isTestAllowed = true;
+// These endpoints hand out coins/gems/items/stats/chests with no cost and MUST
+// NEVER be reachable in production — any authenticated user could self-grant
+// infinite currency. They exist only for local dev and Playwright E2E runs.
+//
+// Enabled outside production, or with an explicit ENABLE_TEST_ENDPOINTS=1
+// opt-in (e.g. a Playwright run against a staging build that sets
+// NODE_ENV=production). In production without that flag they are unmounted.
+export const testEndpointsEnabled =
+  process.env.NODE_ENV !== 'production' || process.env.ENABLE_TEST_ENDPOINTS === '1';
 
-if (!isTestAllowed) {
-  router.use((req, res) => res.status(403).json({ message: 'Test endpoints disabled' }));
-}
+// Defensive guard: even if this router is ever mounted while disabled, refuse
+// every request under it. `/test/ping` (presence) lives outside this router, so
+// it is unaffected. 404 rather than 403 to avoid advertising the endpoints.
+router.use((req, res, next) => {
+  if (!testEndpointsEnabled) return res.status(404).json({ message: 'Not found' });
+  next();
+});
 
 // Give coins to a user
 router.post('/add-coins', authenticate, async (req, res) => {


### PR DESCRIPTION
## Qué

Task P0-Seguridad: **Matar `/api/test/*` en producción** (`backend/test.js:9`, `backend/index.js:157`).

`backend/test.js` exponía `/add-coins`, `/add-gems`, `/add-item`, `/set-stats`, `/add-chests`, `/complete-missions` con `isTestAllowed = true` **incondicional**. Cualquier usuario autenticado en producción podía darse monedas/gemas/items/cofres/stats infinitos.

## Cambios

- `backend/test.js`: se sustituye `isTestAllowed = true` por `export const testEndpointsEnabled = process.env.NODE_ENV !== 'production' || process.env.ENABLE_TEST_ENDPOINTS === '1'`. Guard defensivo `404` dentro del router por si se montara estando deshabilitado.
- `backend/index.js`: el router `/test` se **monta condicionalmente** solo cuando `testEndpointsEnabled`. En producción no existe.

### Detalle importante — `/test/ping`
El handler de presencia `POST /test/ping` está definido **directamente en `apiRouter`** (index.js), fuera del router de `test.js`, y es legítimo en producción. Por eso el gating se hace por **montaje condicional** y no con un catch-all dentro del router (que también habría tragado `/test/ping`). Verificado que sigue funcionando en modo producción.

### Cómo habilitar E2E
Playwright/CI corriendo contra un build `NODE_ENV=production` puede exportar `ENABLE_TEST_ENDPOINTS=1`. En dev normal (`NODE_ENV` != production) siguen activos sin configurar nada.

## Verificación — **integración local** (Postgres efímero en el sandbox)

Sandbox con Postgres 16 efímero + `schema.sql` + `/db/init`, backend arrancado con `DATABASE_URL` local + `JWT_SECRET` dummy. Se registró un usuario real vía `/api/auth/signup` y se ejercitó el flujo con `curl`:

| Modo | `POST /api/test/add-coins` | `POST /api/test/ping` |
|---|---|---|
| `NODE_ENV=development` | ✅ `200 Added 500 coins` | ✅ `{ok:true}` |
| `NODE_ENV=production` | ✅ **`404`** (cheat bloqueado) | ✅ `{ok:true}` (presencia intacta) |
| `production` + `ENABLE_TEST_ENDPOINTS=1` | ✅ `200` (opt-in E2E) | — |

`node --check` OK en ambos ficheros.

## Notas
- No se toca el shim `api/pusher-auth.js` ni CORS aquí; van en tasks P0 separadas.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_