### PR TITLE
feat(security): rate limiting on /auth/login and /reps

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -5,6 +5,7 @@ import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
 import { query } from './db.js';
 import { ensureUsername } from './utils/username.js';
+import { loginLimiter } from './utils/rateLimiters.js';
 
 const router = express.Router();
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
@@ -150,7 +151,7 @@ router.post('/signup', async (req, res) => {
 });
 
 // Manual Login
-router.post('/login', async (req, res) => {
+router.post('/login', loginLimiter, async (req, res) => {
   const { email, password } = req.body;
 
   try {

--- a/backend/index.js
+++ b/backend/index.js
@@ -51,6 +51,11 @@ import { sweepExpiredPacts } from './utils/campaignQuests.js';
 const app = express();
 const PORT = process.env.PORT || 5001;
 
+// Behind Coolify/Traefik (single reverse-proxy hop). Lets express-rate-limit
+// and any IP-based logic read the real client IP from X-Forwarded-For instead
+// of treating every request as coming from the proxy.
+app.set('trust proxy', 1);
+
 // --- SCHEDULED TASKS ---
 // Cron jobs are only useful on long-running Node processes. In serverless
 // deployments, module startup can happen on normal visits and must not send push.

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^7.5.1",
     "google-auth-library": "^10.6.2",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",

--- a/backend/reps.js
+++ b/backend/reps.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import pool, { query } from './db.js';
 import { authenticate } from './middleware.js';
+import { repsLimiter } from './utils/rateLimiters.js';
 import { getExerciseRewards, getBossDamageMultiplier } from './utils/rewards.js';
 import { recalculateUserStats, augmentUserWithLevels } from './utils/stats.js';
 
@@ -45,7 +46,7 @@ router.get('/', authenticate, async (req, res) => {
 });
 
 // Add or update reps for a date
-router.post('/', authenticate, async (req, res) => {
+router.post('/', authenticate, repsLimiter, async (req, res) => {
   const { count, date, exercise_type = 'pullups', added_weight = 0 } = req.body;
   const userId = req.user.id;
 

--- a/backend/utils/rateLimiters.js
+++ b/backend/utils/rateLimiters.js
@@ -1,0 +1,29 @@
+import rateLimit from 'express-rate-limit';
+
+// Rate limiters for abuse-prone endpoints. Behind Coolify/Traefik the app sets
+// `trust proxy` so the real client IP (X-Forwarded-For) is used as the key.
+
+// Brute-force guard on manual login. Keyed by IP. Only failed attempts count
+// (skipSuccessfulRequests) so a legit user hammering the button after a correct
+// login is never locked out.
+export const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 min
+  max: 10,
+  skipSuccessfulRequests: true,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { code: 'ERR_RATE_LIMIT', message: 'Demasiados intentos de inicio de sesión. Inténtalo de nuevo en unos minutos.' },
+});
+
+// Spam guard on rep logging. Keyed by authenticated user id (this limiter is
+// mounted AFTER `authenticate`, so req.user is always present), falling back to
+// IP defensively. Reps are once-per-day-per-exercise anyway, so a low ceiling
+// per minute is plenty of headroom for legit editing while blocking floods.
+export const repsLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 min
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.user?.id || req.ip,
+  message: { code: 'ERR_RATE_LIMIT', message: 'Demasiadas peticiones. Espera un momento.' },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^7.5.1",
         "google-auth-library": "^10.6.2",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
@@ -67,6 +68,7 @@
       },
       "optionalDependencies": {
         "@esbuild/linux-x64": "^0.24.2",
+        "@resvg/resvg-js-linux-x64-gnu": "^2.6.2",
         "@rolldown/binding-linux-x64-gnu": "0.13.2",
         "lightningcss-linux-x64-gnu": "^1.29.1"
       }
@@ -1173,7 +1175,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2779,6 +2780,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {


### PR DESCRIPTION
## Qué

Task P0-Seguridad: **Rate limiting** — no existía en ningún endpoint.

Añade `express-rate-limit` (v7.5.1) con dos limiters en `backend/utils/rateLimiters.js`:

- **`loginLimiter`** — 10 intentos **fallidos** / 15 min por IP en `POST /auth/login`. `skipSuccessfulRequests: true` para que un login correcto nunca cuente ni bloquee a un usuario legítimo. Guarda contra fuerza bruta.
- **`repsLimiter`** — 20 peticiones / min **por usuario autenticado** (keyGenerator = `req.user.id`, montado tras `authenticate`) en `POST /reps`. Guarda contra spam. Como los reps son 1/día/ejercicio, 20/min sobra para edición legítima.

Además `app.set('trust proxy', 1)` en `index.js`: detrás de Coolify/Traefik (un solo hop) permite leer la IP real de `X-Forwarded-For`. Verificado que ningún otro código usa `req.ip`/`trust proxy`, así que el cambio es seguro.

## Verificación — **integración local** (Postgres efímero en el sandbox)

Backend arrancado contra Postgres 16 local con usuarios reales creados vía `/api/auth/signup`, ejercitado con `curl`:

**Login (fuerza bruta)** — 12 intentos con contraseña incorrecta:
```
attempts 1–10 -> 401   (fallo normal, cuentan)
attempts 11–12 -> 429  (bloqueado)
```

**Reps (spam, por usuario)** — 22 `POST /reps` del mismo usuario:
```
req 1–20  -> respuesta del handler
req 21–22 -> 429 (bloqueado)
un usuario DISTINTO en su 1ª petición -> NO 429  (buckets separados por user id)
```
> Nota: en el sandbox el handler de `/reps` devuelve 500 porque a la BD efímera le falta la tabla `items` (deriva de esquema `/db/init`, ajeno a este cambio). El limiter actúa **antes** del handler, así que el 429 se prueba igual con independencia del resultado del handler. `node --check` OK en todos los ficheros tocados.

## Scope
Solo los dos endpoints que pide la task (login + reps). `/auth/signup` y `/auth/google` quedan sin limiter; si se quiere endurecer toda la superficie de auth más adelante, `loginLimiter` es reutilizable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_