### PR TITLE
fix(security): remove *.vercel.app from CORS allowlist

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -84,12 +84,15 @@ if (process.env.VERCEL !== '1') {
 }
 // -----------------------
 
-// CORS allowlist: prod origin, Vercel preview deploys, and localhost dev.
-// In prod the SPA is same-origin with the API, so requests usually carry no
-// Origin header (allowed below); the allowlist guards genuine cross-origin calls.
+// CORS allowlist: prod origin and localhost dev. In prod the SPA is same-origin
+// with the API, so requests usually carry no Origin header (allowed below); the
+// allowlist guards genuine cross-origin calls.
+//
+// NOTE: the previous `/\.vercel\.app$/` entry was a hole — anyone can deploy for
+// free on a *.vercel.app subdomain and would then pass the allowlist with
+// credentials. The app runs on Coolify now, so all Vercel origins are removed.
 const allowedOrigins = [
-  'https://reppy-weld.vercel.app',
-  /\.vercel\.app$/, // preview deployments
+  'https://reppy.romandev.app',
   'http://localhost:5173',
   'http://localhost:5174',
   'http://localhost:5001',


### PR DESCRIPTION
## Qué

Task P0-Seguridad: **Quitar CORS `*.vercel.app`** (`backend/index.js:92`).

La entrada `/\.vercel\.app$/` del allowlist era un agujero: cualquiera puede desplegar gratis en un subdominio `*.vercel.app` y pasaría CORS **con `credentials: true`**. La app ya corre en Coolify, no en Vercel.

## Cambios (`backend/index.js`)

- Eliminadas todas las entradas Vercel: el regex `/\.vercel\.app$/` y `https://reppy-weld.vercel.app`.
- Añadido el origen de producción real: `https://reppy.romandev.app`.
- Se mantienen los orígenes de dev (`localhost:5173/5174/5001`) y el override `FRONTEND_URL`.

## Verificación — **integración local** (backend arrancado en el sandbox)

`curl` con distintos `Origin` contra `/api/health` (`node --check` OK):

| Origin | Esperado | ACAO devuelto |
|---|---|---|
| `https://reppy.romandev.app` | permitido | ✅ `Access-Control-Allow-Origin: https://reppy.romandev.app` |
| `https://evil-attacker.vercel.app` | rechazado | ✅ sin cabecera ACAO |
| `https://reppy-weld.vercel.app` | rechazado | ✅ sin cabecera ACAO |
| `http://localhost:5173` | permitido | ✅ ACAO presente |
| (sin `Origin`, same-origin) | permitido | ✅ HTTP 200 |

Sin cabecera `Access-Control-Allow-Origin` el navegador bloquea la respuesta cross-origin, que es la propiedad de seguridad buscada. El rechazo produce un 500 (el callback de `cors` lanza un Error hacia el handler global) — comportamiento preexistente, fuera del scope de esta task.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_