### PR TITLE
fix(missions): make buy_legendary completable (real rarity strings)

### DIFF
--- a/backend/shop.js
+++ b/backend/shop.js
@@ -527,7 +527,10 @@ router.post('/buy/:id', authenticate, async (req, res) => {
       // Mission Triggers (separate rows; run after commit)
       await updateMissionProgress(userId, 'buy_any', 1);
       await updateMissionProgress(userId, 'spend_coins', finalDeduction);
-      if (item.rarity === 'Legendary' || item.rarity === 'Calisthenics') {
+      // Real rarities are lowercase Spanish: legendary / calistenico (the two
+      // top tiers). The previous 'Legendary'/'Calisthenics' comparison never
+      // matched, so the buy_legendary mission was uncompletable.
+      if (item.rarity === 'legendary' || item.rarity === 'calistenico') {
         await updateMissionProgress(userId, 'buy_legendary', 1);
       }
 


### PR DESCRIPTION
## Qué

Task P0-Promesas rotas: **Misión `buy_legendary` incompletable** (`backend/shop.js:530`).

El disparador comparaba `item.rarity` contra `'Legendary'` / `'Calisthenics'`, pero las rarezas reales se guardan en minúscula y español: `legendary` / `calistenico`. La comparación **nunca** matcheaba → la misión "Legado Legendario" era imposible de completar.

## Cambio

`backend/shop.js`: comparar contra `'legendary'` / `'calistenico'` (las dos rarezas top, según CLAUDE.md).

## Verificación — **integración local** (Postgres efímero en el sandbox)

Insertados dos items reales (`rarity='legendary'` y `rarity='calistenico'`) y evaluada la condición vieja vs nueva contra las filas reales de la BD:

```
Test Legendary Sword  (rarity=legendary):   OLD triggers=false  NEW triggers=true
Test Calistenico Armor (rarity=calistenico): OLD triggers=false  NEW triggers=true
```

`node --check backend/shop.js`: OK.

> El flujo de compra completo (que dispararía la misión) no se ejercitó de extremo a extremo: en el sandbox faltan las tablas `missions`/`user_missions` (no están en `schema.sql`) y `/buy` exige rotación diaria/daily-deal para gear no-customizable. Como el bug es una comparación de igualdad de strings, se probó directamente el punto exacto del fallo contra datos reales, que es concluyente.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_