### PR TITLE
fix(seed): Spanish rarities in seed_rpg_items (especial/calistenico)

### DIFF
--- a/backend/scripts/seed_rpg_items.js
+++ b/backend/scripts/seed_rpg_items.js
@@ -12,8 +12,8 @@ async function seed() {
     // WEAPON
     { name: 'Espada de Madera', type: 'weapon', rarity: 'common', stats: { dex: 1, str: 1 }, description: 'Ideal para practicar.' },
     { name: 'Hacha de Guerra', type: 'weapon', rarity: 'rare', stats: { str: 5 }, description: 'Pesada y letal.' },
-    { name: 'Katana de Electrum', type: 'weapon', rarity: 'special', stats: { dex: 8, str: 2 }, description: 'Corta el aire mismo.' },
-    { name: 'Maza Calisténica', type: 'weapon', rarity: 'calisthenic', stats: { str: 15, end: 5 }, description: 'Forjada en el fuego de mil dominadas.' },
+    { name: 'Katana de Electrum', type: 'weapon', rarity: 'especial', stats: { dex: 8, str: 2 }, description: 'Corta el aire mismo.' },
+    { name: 'Maza Calisténica', type: 'weapon', rarity: 'calistenico', stats: { str: 15, end: 5 }, description: 'Forjada en el fuego de mil dominadas.' },
     
     // ARMOR
     { name: 'Túnica de Tela', type: 'armor', rarity: 'common', stats: { end: 1 }, description: 'Ligera y cómoda.' },


### PR DESCRIPTION
## Qué

Task P0-Promesas rotas: **`scripts/seed_rpg_items.js` con rarezas en inglés** (`special`, `calisthenic`).

Dos items del seed usaban rarezas inexistentes en el modelo (`special`, `calisthenic`). Las queries de loot de cofres filtran por las rarezas reales (`WHERE rarity = 'especial'` / `'calistenico'`), así que estos items quedaban **huérfanos**: nunca dropeaban.

## Cambio

`backend/scripts/seed_rpg_items.js`:
- `Katana de Electrum`: `special` → `especial`
- `Maza Calisténica`: `calisthenic` → `calistenico`

## Verificación — **integración local** (Postgres efímero en el sandbox)

Ejecutado el seed real contra Postgres 16 local:

```
name                | rarity
--------------------+-------------
Katana de Electrum  | especial
Maza Calisténica    | calistenico

chest query WHERE rarity='especial' AND name='Katana de Electrum' -> 1 fila (encontrada)
items con rareza 'special'/'calisthenic' restantes -> 0
```

`node --check`: OK.

## Nota (fuera de scope)
El item `Botas de Hermes` del mismo seed tiene `stats: { dex: 10, agi: 5 }` y `agi` no es una stat válida del modelo (str/dex/end/vig/int/fth/cha/pwr). No lo toco aquí porque esta task es solo de rarezas; lo dejo señalado por si merece una task aparte.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_