### PR TITLE
fix(campaign): grant NPC quest XP reward on claim

### DIFF
--- a/backend/utils/campaignQuests.js
+++ b/backend/utils/campaignQuests.js
@@ -242,11 +242,20 @@ export async function claimQuest(client, run, questId, userId) {
   const rewards = qRes.rows[0]?.rewards || {};
   const coins = Number(rewards.coins) || 0;
   const gems = Number(rewards.gems) || 0;
+  // The JSON promised `xp` but it was never granted. XP is paid into cha_xp —
+  // the persistent, additive XP bucket that feeds total_xp/current_level and is
+  // NOT recomputed by recalculateUserStats. This mirrors how training-plan XP
+  // rewards are granted (see training.js).
+  const xp = Math.max(0, Math.floor(Number(rewards.xp) || 0));
 
-  if (coins || gems) {
+  if (coins || gems || xp) {
     await client.query(
-      'UPDATE users SET reppy_coins = reppy_coins + $1, reppy_gems = reppy_gems + $2 WHERE id = $3',
-      [coins, gems, userId]
+      `UPDATE users
+       SET reppy_coins = reppy_coins + $1,
+           reppy_gems = reppy_gems + $2,
+           cha_xp = COALESCE(cha_xp, 0) + $3
+       WHERE id = $4`,
+      [coins, gems, xp, userId]
     );
     if (gems > 0) {
       await client.query(
@@ -271,7 +280,7 @@ export async function claimQuest(client, run, questId, userId) {
     blessing = { multiplier: Number(buff.multiplier), hours: Number(buff.hours) };
   }
 
-  return { status: 200, body: { message: 'Recompensa reclamada', reward_coins: coins, reward_gems: gems, blessing } };
+  return { status: 200, body: { message: 'Recompensa reclamada', reward_coins: coins, reward_gems: gems, reward_xp: xp, blessing } };
 }
 
 /**


### PR DESCRIPTION
## Qué

Task P0-Promesas rotas: **XP de quests de NPC ignorado** — `backend/utils/campaignQuests.js` `claimQuest` pagaba coins/gems/buff pero el campo `xp` del JSON era letra muerta. *(La task ofrece "pagarlo o quitarlo del JSON" → elegido pagarlo.)*

## Por qué pagarlo en `cha_xp` (y no inventar un mecanismo nuevo)

`recalculateUserStats` **recalcula** str/dex/end/vig/int/fth + `total_xp` + `current_level` de forma pura a partir del historial de actividad (reps, blogs, daño a boss, racha). Escribir XP plano en esas columnas se sobrescribiría en el siguiente recalc.

`cha_xp` es la **única** bolsa de XP persistente y aditiva: se lee del usuario, alimenta `total_xp`/nivel y **no** se recalcula. Ya es el sumidero de XP plano usado por otros sistemas:
- `training.js:1025` — XP de planes de entrenamiento (`SET cha_xp = COALESCE(cha_xp,0) + $1`).
- `social_feed.js` — +5/+20 cha_xp por acciones sociales.

Pagar la XP de quest en `cha_xp` honra la promesa **usando un patrón ya existente**, sin tocar la fórmula de progresión ni tomar decisiones de balance nuevas.

## Cambio (`backend/utils/campaignQuests.js`)

- `claimQuest` suma `rewards.xp` a `cha_xp` en el mismo UPDATE que coins/gems.
- La XP reclamada se devuelve en el body como `reward_xp`.

## Verificación — **integración local** (Postgres efímero + seed real de campaña)

Quest `elara-clear-bandits` (`{coins:500, gems:5, xp:120}`), estado `completed`, invocando `claimQuest` real:

```
response body = {"reward_coins":500,"reward_gems":5,"reward_xp":120,"blessing":null,...}
cha_xp: 0 -> 120  (delta +120)
coins:  0 -> 500  (delta +500)
gems:   0 -> 5    (delta +5)
re-claim: status=400 "Ya reclamada"; cha_xp sigue 120  (idempotente, sin re-pago)
```

`node --check`: OK.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_