### PR TITLE
docs(economy): curves analysis tool + report (P1 pre-rebalance)

### DIFF
--- a/backend/scripts/analyze_economy_curves.js
+++ b/backend/scripts/analyze_economy_curves.js
@@ -1,0 +1,102 @@
+/**
+ * Economy & combat curves analysis (the "hoja de cálculo" from the 2026-07 audit).
+ *
+ * Purpose: compute — from the REAL in-code formulas — the curves the audit flags,
+ * so number-tuning (streak cap, roulette EV, FE snowball, difficulty curve, …) is
+ * done on data instead of blind. This script imports the actual game functions
+ * (calculateDamage, scaleEnemyHp) so the numbers match production exactly.
+ *
+ * Run: `node backend/scripts/analyze_economy_curves.js`
+ * It touches NO database and has no side effects — pure calculation.
+ *
+ * MODEL ASSUMPTIONS (stated explicitly; tweak here to explore scenarios):
+ *  - A player at global level L is modelled with every combat stat level = L
+ *    (str/dex/end/vig/int/fth/cha), no gear, no potions, no skill perks. This is
+ *    a deliberately simple "stats track level" baseline to expose the STRUCTURAL
+ *    shape of each curve, not a claim about a specific real player.
+ *  - Damage shown is deterministic single-rep pull-up damage (no crit roll), so
+ *    it is reproducible; the crit expectation is reported separately.
+ */
+import { calculateDamage } from '../utils/damage.js';
+import { scaleEnemyHp } from '../utils/campaignEngine.js';
+
+function modelUser(L) {
+  const lvl = { current_level: L };
+  for (const s of ['str', 'dex', 'end', 'vig', 'int', 'fth', 'cha']) {
+    lvl[`${s}_lvl`] = L;
+    lvl[`base_${s}_lvl`] = L;
+  }
+  return lvl;
+}
+
+// Deterministic single-rep pull-up damage (no crit, no gear, no buffs).
+function damagePerRep(L) {
+  const u = modelUser(L);
+  const r = calculateDamage(u, 1, 'pullups', null, true, true, null, 0);
+  return r.totalDamage;
+}
+
+// Expected crit-weighted per-rep damage: crit chance = min(80, dex*2.5 + vig*0.5),
+// crit mult = 2 + dex*0.1. Expected weight per rep = (1-p) + p*mult.
+function expectedCritMultiplier(L) {
+  const p = Math.min(80, L * 2.5 + L * 0.5) / 100;
+  const mult = 2.0 + L * 0.1;
+  return (1 - p) + p * mult;
+}
+
+console.log('=== 1) PLAYER DAMAGE vs ENEMY HP by level ===');
+console.log('(model: every stat level = global level; 1 pull-up rep; campaign enemy base_hp=1200 tier1)');
+console.log('lvl | dmg/rep(noCrit) | dmg/rep(expCrit) | enemyHP | reps-to-kill(expCrit) | dmg growth×  | HP growth×');
+let prevDmg = null, prevHp = null;
+for (const L of [1, 5, 10, 20, 30, 50, 75, 100]) {
+  const d = damagePerRep(L);
+  const dCrit = d * expectedCritMultiplier(L);
+  const hp = scaleEnemyHp({ base_hp: 1200, tier: 1, scaling: {} }, null, L, 0);
+  const rtk = (hp / dCrit);
+  const dg = prevDmg ? (dCrit / prevDmg) : 1;
+  const hg = prevHp ? (hp / prevHp) : 1;
+  console.log(
+    `${String(L).padStart(3)} | ${d.toFixed(0).padStart(15)} | ${dCrit.toFixed(0).padStart(16)} | ${hp.toFixed(0).padStart(7)} | ${rtk.toFixed(2).padStart(21)} | ${dg.toFixed(2).padStart(11)}x | ${hg.toFixed(2).padStart(9)}x`
+  );
+  prevDmg = dCrit; prevHp = hp;
+}
+console.log('→ reps-to-kill FALLS as level rises: player damage is superlinear (levelMult=1+L/2, fthScale, flat divineBonus=fth*25), enemy HP is ~linear (1+0.05·L). Enemies melt faster the further you get.\n');
+
+console.log('=== 2) FLAT DIVINE BONUS (FE snowball) share of per-rep damage ===');
+console.log('(divineBonus = fth_lvl * 25, added flat per rep BEFORE multipliers stack)');
+console.log('lvl | dmg/rep(noCrit) | flat divineBonus | divine share %');
+for (const L of [1, 5, 10, 20, 30, 50, 100]) {
+  const d = damagePerRep(L);
+  const divine = L * 25;
+  console.log(`${String(L).padStart(3)} | ${d.toFixed(0).padStart(15)} | ${String(divine).padStart(16)} | ${(100 * divine / d).toFixed(1).padStart(13)}%`);
+}
+console.log('→ FE (fth) contributes a flat +25/level per rep that also feeds XP→more FE (positive feedback). See damage.js divineBonus + stats.js FE-from-damage.\n');
+
+console.log('=== 3) DAILY COIN INCOME: training vs passive ===');
+const ROULETTE_4H_COINS_EV = (40*0.425 + 75*0.18 + 120*0.10 + 200*0.06 + 350*0.03 + 600*0.01); // coins-only EV/spin
+const spinsPerDay = 24 / 4; // 4h cooldown
+const roulettePerDay = ROULETTE_4H_COINS_EV * spinsPerDay;
+console.log(`roulette 4h coins-EV/spin = ${ROULETTE_4H_COINS_EV.toFixed(1)}  → ${spinsPerDay} spins/day = ${roulettePerDay.toFixed(0)} coins/day (coins only; excl gems/consumables/chests)`);
+console.log('streak reward = streak * 50 (UNCAPPED). training(pullups) = reps * 1.');
+console.log('day | streakReward | roulette | training(50r) | training(200r) | training share @50r | @200r');
+for (const day of [1, 7, 14, 30, 60, 100]) {
+  const streakReward = day * 50;
+  for (const tr of [null]) void tr;
+  const t50 = 50, t200 = 200;
+  const total50 = streakReward + roulettePerDay + t50;
+  const total200 = streakReward + roulettePerDay + t200;
+  console.log(
+    `${String(day).padStart(3)} | ${String(streakReward).padStart(12)} | ${roulettePerDay.toFixed(0).padStart(8)} | ${String(t50).padStart(13)} | ${String(t200).padStart(14)} | ${(100*t50/total50).toFixed(1).padStart(18)}% | ${(100*t200/total200).toFixed(1)}%`
+  );
+}
+console.log('→ On a long streak, actually TRAINING is a single-digit % of daily coin income; opening the app (streak + roulette) dominates. The app rewards showing up, not training.\n');
+
+console.log('=== 4) STREAK REWARD: current vs audit proposals ===');
+console.log('day | current(50*n) | proposalA(50+5*min(n,30)) | milestones(7/30/100)');
+const milestone = (n) => (n >= 100 ? 1000 : n >= 30 ? 400 : n >= 7 ? 150 : 50);
+for (const day of [1, 7, 14, 30, 60, 100]) {
+  const cur = day * 50;
+  const a = 50 + 5 * Math.min(day, 30);
+  console.log(`${String(day).padStart(3)} | ${String(cur).padStart(13)} | ${String(a).padStart(25)} | ${String(milestone(day)).padStart(20)}`);
+}
+console.log('→ Current is unbounded (day100 = 5000/day for a single rep). Both proposals bound it. (Decision pending — see ⏸️ in tasks.)');

--- a/docs/economy-curves-2026-07.md
+++ b/docs/economy-curves-2026-07.md
@@ -1,0 +1,98 @@
+# Curvas de economía y combate — análisis (2026-07)
+
+Este documento es la "hoja de cálculo de curvas" que pide la auditoría P1 antes de tocar números.
+Todo se calcula con las **fórmulas reales del código** (`calculateDamage`, `scaleEnemyHp`, tablas de ruleta),
+mediante `backend/scripts/analyze_economy_curves.js` (sin BD, sin efectos). Reproducir con:
+
+```bash
+node backend/scripts/analyze_economy_curves.js
+```
+
+**Modelo** (declarado en el script): jugador de nivel global `L` con cada stat de combate = `L`, sin gear,
+sin pociones, sin perks. Es un baseline "los stats siguen al nivel" para exponer la **forma estructural**
+de cada curva, no un jugador concreto. El daño es 1 rep de dominadas determinista (sin crit); el crit
+esperado se reporta aparte.
+
+---
+
+## 1. Daño del jugador vs HP enemigo (la curva de dificultad rota)
+
+| lvl | dmg/rep (sin crit) | dmg/rep (crit esperado) | HP enemigo | reps-para-matar |
+|----:|----:|----:|----:|----:|
+| 1   | 30     | 31      | 1260 | 40.66 |
+| 5   | 143    | 175     | 1500 | 8.56 |
+| 10  | 300    | 480     | 1800 | 3.75 |
+| 20  | 710    | 1 988   | 2400 | 1.21 |
+| 30  | 1 365  | 5 733   | 3000 | 0.52 |
+| 50  | 4 409  | 25 572  | 4200 | 0.16 |
+| 75  | 16 403 | 127 943 | 5700 | 0.04 |
+| 100 | 50 695 | 496 811 | 7200 | 0.01 |
+
+**Las reps-para-matar caen de ~41 (nivel 1) a ~0.01 (nivel 100).** El daño del jugador es superlineal
+(`levelMult = 1 + L/2`, `fthScale`, `divineBonus = fth·25` plano por rep, y el crit multiplicando encima),
+mientras el HP enemigo escala ~lineal (`1 + 0.05·L`). Los enemigos se derriten más cuanto más avanzas —
+justo lo contrario de una curva de dificultad. **El HP debería escalar con el daño esperado del jugador**,
+no lineal por nivel.
+
+## 2. Bola de nieve de FE (Fe/`fth`)
+
+`divineBonus = fth_lvl · 25` se suma **plano por rep** antes de que los multiplicadores se apilen, y a la vez
+el daño a boss genera XP de FE (`stats.js`, FE = daño/50) → más FE → más daño: feedback positivo puro.
+
+| lvl | dmg/rep (sin crit) | divineBonus plano | % del daño que es FE plana |
+|----:|----:|----:|----:|
+| 1   | 30    | 25   | 83.3% |
+| 5   | 143   | 125  | 87.4% |
+| 10  | 300   | 250  | 83.3% |
+| 30  | 1 365 | 750  | 54.9% |
+| 50  | 4 409 | 1250 | 28.4% |
+| 100 | 50 695| 2500 | 4.9% |
+
+En niveles bajos-medios el grueso del daño es el bono plano de FE. Domar la bola de nieve = hacer el bono
+% pequeño y que FE suba por otra vía (raids/quests), como propone la auditoría.
+
+## 3. Ingreso diario de monedas: entrenar vs pasivo
+
+- **Ruleta 4h**: EV de monedas/giro = `40·0.425 + 75·0.18 + 120·0.10 + 200·0.06 + 350·0.03 + 600·0.01 = 71`.
+  Con cooldown de 4h → 6 giros/día = **426 monedas/día** (solo monedas; sin contar gemas/consumibles/cofres).
+- **Racha**: `racha · 50`, **sin tope**.
+- **Entrenar** (dominadas): `reps · 1`.
+
+| día | racha (50·n) | ruleta | entreno 50r | entreno 200r | % entreno @50r | @200r |
+|----:|----:|----:|----:|----:|----:|----:|
+| 1   | 50    | 426 | 50 | 200 | 9.5% | 29.6% |
+| 7   | 350   | 426 | 50 | 200 | 6.1% | 20.5% |
+| 14  | 700   | 426 | 50 | 200 | 4.3% | 15.1% |
+| 30  | 1 500 | 426 | 50 | 200 | 2.5% | 9.4% |
+| 60  | 3 000 | 426 | 50 | 200 | 1.4% | 5.5% |
+| 100 | 5 000 | 426 | 50 | 200 | 0.9% | 3.6% |
+
+**Con una racha larga, entrenar es un % de un solo dígito del ingreso diario.** Abrir la app (racha + ruleta)
+domina. La app premia aparecer, no entrenar — confirma la tesis de la auditoría.
+
+## 4. Recompensa de racha: actual vs propuestas
+
+| día | actual (50·n) | Propuesta A (50 + 5·min(n,30)) | Hitos (7/30/100) |
+|----:|----:|----:|----:|
+| 1   | 50    | 55  | 50 |
+| 7   | 350   | 85  | 150 |
+| 14  | 700   | 120 | 150 |
+| 30  | 1 500 | 200 | 400 |
+| 60  | 3 000 | 200 | 400 |
+| 100 | 5 000 | 200 | 1000 |
+
+La actual es no acotada (día 100 = 5000/día por **una** rep). Ambas propuestas la acotan. La elección del
+número exacto es de Roman (ver ⏸️ en el fichero de tasks).
+
+---
+
+## Implicaciones para las tasks P1 (todas pendientes de decisión de Roman)
+
+1. **Cap a la racha** — necesario; da igual la fórmula, cualquiera acota los 5000/día. §4.
+2. **Bajar EV de la ruleta 4h** — 426/día pasivos por clicar. Reducir pesos de premios altos o subир cooldown. §3.
+3. **Domar FE** — el bono plano `fth·25/rep` es el 80%+ del daño temprano y se autoalimenta. §2.
+4. **Curva de dificultad** — HP enemigo debe escalar con el daño esperado, no lineal. §1.
+5. **Pociones DEX de crit / prestigio ROI** — no modeladas aquí en detalle; el crit esperado de §1 ya muestra
+   cuánto multiplica el crit (a nivel 100, ×~10 sobre el daño sin crit).
+
+Este análisis es la base; los números concretos los decide Roman sobre estas curvas.


### PR DESCRIPTION
## Qué

Task P1-Rebalance: **Hoja de cálculo de curvas** (daño/HP/monedas por nivel y día) *antes de tocar números*.

Es la task que la sección pide hacer primero ("empieza por una hoja de cálculo", "antes de tocar números"). No cambia ningún número de balance — es puro análisis para que el rebalanceo no sea a ciegas.

## Cambios

- **`backend/scripts/analyze_economy_curves.js`** — calcula las curvas desde las **fórmulas reales del código** (importa `calculateDamage` y `scaleEnemyHp`; EV de ruleta desde la tabla real de premios). Sin BD, sin efectos. Modelo declarado explícitamente en el script.
- **`docs/economy-curves-2026-07.md`** — informe con las tablas y conclusiones.

## Hallazgos (números exactos del código)

1. **Curva de dificultad invertida**: reps-para-matar cae de **~41 (nivel 1) a ~0.01 (nivel 100)**. Daño superlineal (`levelMult=1+L/2`, `fthScale`, `divineBonus=fth·25` plano, + crit) vs HP enemigo ~lineal (`1+0.05·L`). Los enemigos se derriten más cuanto más avanzas.
2. **Bola de nieve de FE**: el bono plano `fth·25/rep` es **>80% del daño por rep en niveles bajos-medios** y se autoalimenta (daño→XP de FE→más daño).
3. **Entrenar ≈ nada del ingreso**: ruleta 4h = **426 monedas/día** pasivas (EV real), racha `50·n` sin tope = 5000/día al día 100. Con racha larga, entrenar es un **% de un dígito** del ingreso diario.
4. Tabla comparando la recompensa de racha actual vs las dos propuestas de la auditoría.

## Verificación

`node --check` OK. Script ejecutado; su salida real es la fuente de las tablas del informe (incluida en el PR). No toca BD ni balance.

## Nota
Las tasks de tuning de números (cap de racha, EV ruleta, FE, curva de dificultad, pociones DEX, prestigio ROI) quedan como **⏸️ pendientes de decisión de Roman** sobre estas curvas — se marcan en el fichero de tasks en commits aparte a `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_