### PR TITLE
fix(retention): segment referral reminder, send at most once

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -679,6 +679,8 @@ async function ensureAllTrainingExercisesExist() {
 async function ensureSchemaMigrations() {
   try {
     await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS last_daily_spin_at TIMESTAMP WITH TIME ZONE');
+    // Referral-invite push is sent at most once per user (see referralReminders.js).
+    await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_reminder_sent BOOLEAN DEFAULT FALSE');
     // Per-user "feature seen" flags that drive the NEW badges/dots.
     await query(`CREATE TABLE IF NOT EXISTS user_feature_seen (
         user_id     VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -317,6 +317,8 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS skill_perks JSONB DEFAULT '{}'::jsonb
 ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code VARCHAR(20) UNIQUE;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_by VARCHAR(255) REFERENCES users(id);
 ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_reward_given BOOLEAN DEFAULT FALSE;
+-- Ensures the referral-invite push is sent at most once per user (see referralReminders.js).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_reminder_sent BOOLEAN DEFAULT FALSE;
 CREATE INDEX IF NOT EXISTS idx_users_referral_code ON users(referral_code);
 CREATE INDEX IF NOT EXISTS idx_users_referred_by ON users(referred_by);
 

--- a/backend/utils/referralReminders.js
+++ b/backend/utils/referralReminders.js
@@ -3,15 +3,32 @@ import { sendPushNotification } from './pushNotifications.js';
 
 export async function runReferralReminders() {
   try {
+    // Segmented, one-shot referral nudge (was: blast to EVERY push-enabled user
+    // twice a month — spam that burns the push channel). Only target users who:
+    //   - have push enabled,
+    //   - registered more than 7 days ago (established, not brand-new),
+    //   - have trained in the last 14 days (active, not churned — winback owns those),
+    //   - have never successfully referred anyone,
+    //   - have not already received this reminder (referral_reminder_sent).
+    // The `referral_reminder_sent` flag guarantees at most one send per user
+    // ever, even though the cron fires twice a month.
     const result = await query(`
       SELECT DISTINCT ps.user_id
       FROM push_subscriptions ps
       JOIN users u ON ps.user_id = u.id
       WHERE COALESCE(u.push_disabled, false) = false
+        AND COALESCE(u.referral_reminder_sent, false) = false
+        AND u.created_at < NOW() - INTERVAL '7 days'
+        AND NOT EXISTS (SELECT 1 FROM users r WHERE r.referred_by = u.id)
+        AND EXISTS (
+          SELECT 1 FROM reps rp
+          WHERE rp.user_id = u.id AND rp.date >= (CURRENT_DATE - INTERVAL '14 days')
+        )
     `);
 
-    console.log(`[REFERRAL_REMINDER] Enviando a ${result.rows.length} usuarios.`);
+    console.log(`[REFERRAL_REMINDER] Elegibles: ${result.rows.length} usuarios.`);
     let sentCount = 0;
+    const sentIds = [];
 
     for (const row of result.rows) {
       await sendPushNotification(row.user_id, {
@@ -22,7 +39,16 @@ export async function runReferralReminders() {
           type: 'REFERRAL_REMINDER'
         }
       });
+      sentIds.push(row.user_id);
       sentCount += 1;
+    }
+
+    // Mark as sent so no user ever receives this reminder twice.
+    if (sentIds.length > 0) {
+      await query(
+        'UPDATE users SET referral_reminder_sent = true WHERE id = ANY($1)',
+        [sentIds]
+      );
     }
 
     console.log(`[REFERRAL_REMINDER] Enviadas ${sentCount} notificaciones.`);


### PR DESCRIPTION
## Qué

Task P1-Retención: **Matar/segmentar el blast de referral** — `backend/utils/referralReminders.js` enviaba a **TODOS** los usuarios con push, los días 1 y 16 de cada mes. Spam que quema el canal push.

Spec de la auditoría: *"Solo activos >7 días que nunca refirieron, máx 1 vez."*

## Cambios

**`backend/utils/referralReminders.js`** — la query ahora selecciona solo usuarios que:
- tienen push activado,
- se registraron hace **más de 7 días**,
- entrenaron en los **últimos 14 días** (activos, no churned — de esos se encarga el winback),
- **nunca refirieron** a nadie (`NOT EXISTS` referido con `referred_by = u.id`),
- **no han recibido ya** este recordatorio.

Tras enviar, marca `referral_reminder_sent = true` → **máx 1 envío por usuario de por vida**, aunque el cron siga disparándose 2×/mes.

**Esquema** — nueva columna `users.referral_reminder_sent BOOLEAN DEFAULT FALSE` en `schema.sql` y en `ensureSchemaMigrations()` (idempotente, se aplica al arrancar).

## Verificación — **integración local** (Postgres efímero)

6 usuarios cubriendo cada rama del filtro:

| usuario | condición | ¿enviado? |
|---|---|---|
| `ok_user` | 30d, push on, activo 2d, sin referir | ✅ **sí** |
| `newbie` | 3d (demasiado nuevo) | ❌ no |
| `churned` | activo hace 30d (inactivo) | ❌ no |
| `pushoff` | push desactivado | ❌ no |
| `alreadysent` | flag ya en true | ❌ no |
| `referrer` | ya refirió a alguien | ❌ no |

```
sentCount = 1        (solo ok_user)
flagged = [ok_user]  (flag puesto solo a ok_user)
second run sentCount = 0   (one-shot: no re-envía)
```

`node --check` OK en los ficheros tocados. `sendPushNotification` degrada sin VAPID (no crashea).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_