### PR TITLE
feat(retention): daily "your rival overtook you" push

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -45,6 +45,7 @@ import { authenticate } from './middleware.js';
 import cron from 'node-cron';
 import { runStreakReminders } from './utils/streakReminders.js';
 import { runReferralReminders } from './utils/referralReminders.js';
+import { runRivalReminders } from './utils/rivalReminders.js';
 import { autoFinishExpiredFights } from './utils/pvp_cleanup.js';
 import { sweepExpiredPacts } from './utils/campaignQuests.js';
 
@@ -61,6 +62,13 @@ if (process.env.VERCEL !== '1') {
     runStreakReminders()
       .then(count => console.log(`[CRON] Recordatorios enviados: ${count}`))
       .catch(err => console.error('[CRON] Error en recordatorios:', err));
+  });
+  // "Your rival overtook you" push, once a day at 19:00 (after streak reminders).
+  cron.schedule('0 19 * * *', () => {
+    console.log('[CRON] Iniciando recordatorios de rival...');
+    runRivalReminders()
+      .then(count => console.log(`[CRON] Rival reminders enviados: ${count}`))
+      .catch(err => console.error('[CRON] Error en rival reminders:', err));
   });
   // Referral reminder every 15 days at 12:00 (days 1 and 16 of each month)
   cron.schedule('0 12 1,16 * *', () => {

--- a/backend/utils/rivalReminders.js
+++ b/backend/utils/rivalReminders.js
@@ -1,0 +1,69 @@
+import { query } from '../db.js';
+import { sendPushNotification } from './pushNotifications.js';
+
+/**
+ * Daily "your rival overtook you" push (FOMO / winback-lite).
+ *
+ * Reuses the exact weekly-ranking rivalry logic that already powers
+ * GET /social-feed/stats (social_feed.js): for each user, the "rival" is the
+ * person one rank above them in this week's reps ranking. Here it is computed
+ * set-based for ALL eligible users in a single query instead of per-request.
+ *
+ * Only notifies users who: have push enabled, are public, trained this week
+ * (weekly_reps > 0 — relevant and active), are not rank 1, and whose rival is
+ * genuinely ahead. RANK() (not DENSE_RANK) matches the live endpoint's
+ * semantics exactly.
+ */
+export async function runRivalReminders() {
+  try {
+    const weekStart = new Date();
+    weekStart.setDate(weekStart.getDate() - weekStart.getDay());
+    const weekStartStr = weekStart.toISOString().slice(0, 10);
+
+    const res = await query(
+      `WITH weekly AS (
+         SELECT u.id, u.name,
+                COALESCE(SUM(CASE WHEN COALESCE(e.unit, 'reps') = 'seconds' THEN 0 ELSE r.count END), 0)::int AS weekly_reps,
+                RANK() OVER (ORDER BY COALESCE(SUM(CASE WHEN COALESCE(e.unit, 'reps') = 'seconds' THEN 0 ELSE r.count END), 0) DESC) AS rank
+         FROM users u
+         LEFT JOIN reps r ON r.user_id = u.id AND r.date >= $1
+         LEFT JOIN exercises e ON e.slug = r.exercise_type
+         WHERE u.is_private = false
+         GROUP BY u.id, u.name
+       )
+       SELECT DISTINCT ON (me.id)
+              me.id AS user_id,
+              riv.name AS rival_name,
+              (riv.weekly_reps - me.weekly_reps)::int AS reps_diff
+       FROM weekly me
+       JOIN weekly riv ON riv.rank = me.rank - 1
+       JOIN push_subscriptions ps ON ps.user_id = me.id
+       JOIN users u ON u.id = me.id
+       WHERE COALESCE(u.push_disabled, false) = false
+         AND me.rank > 1
+         AND me.weekly_reps > 0
+         AND riv.weekly_reps > me.weekly_reps
+       ORDER BY me.id, (riv.weekly_reps - me.weekly_reps) ASC`,
+      [weekStartStr]
+    );
+
+    console.log(`[RIVAL_REMINDER] Elegibles: ${res.rows.length} usuarios.`);
+    let sent = 0;
+
+    for (const row of res.rows) {
+      const diff = row.reps_diff;
+      await sendPushNotification(row.user_id, {
+        title: '¡Te han adelantado! 😤',
+        body: `${row.rival_name} te saca ${diff} reps esta semana. ¿Vas a dejar que gane?`,
+        data: { url: '/social', type: 'RIVAL_OVERTAKE' },
+      });
+      sent += 1;
+    }
+
+    console.log(`[RIVAL_REMINDER] Enviadas ${sent} notificaciones.`);
+    return sent;
+  } catch (error) {
+    console.error('[RIVAL_REMINDER] Error:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Qué

Task P1-Retención: **Push "tu rival te adelantó"** — la query ya existe en `social_feed.js` `/stats`; dispararla 1×/día. Reutilización pura.

## Cambios

- **`backend/utils/rivalReminders.js`** (nuevo) — `runRivalReminders()` reutiliza la misma lógica de ranking semanal que `GET /social-feed/stats`, pero calculada **set-based para todos los usuarios elegibles** en una sola query (en vez de por-request). Para cada usuario, el "rival" es quien está un puesto por encima esta semana; si va por delante, se envía un push FOMO con `url:/social`.
- **`backend/index.js`** — cron diario a las 19:00 (tras los recordatorios de racha) que lo dispara.

Solo notifica a usuarios con push activado, públicos, que **entrenaron esta semana** (activos), que **no son rank 1**, y cuyo rival va **realmente por delante**. Usa `RANK()` para replicar la semántica del endpoint vivo.

## Verificación — **integración local** (Postgres efímero)

Ranking de prueba (reps esta semana): `rk_top`(1M) > `rk_mid`(900k) > `rk_pushoff`(850k) > `rk_low`(800k); más `rk_zero`(0) y `rk_priv`(privado):

```
notificados: rk_mid (rival=rk_top, +100000), rk_low (rival=rk_pushoff, +50000)
NO notificados: rk_top (rank1), rk_zero (0 reps), rk_priv (privado), rk_pushoff (push off)
```

Todo correcto: rank 1 sin rival no recibe; usuarios sin reps esta semana no reciben; privados salen del ranking; push desactivado no recibe (pero **sí** puede ser el rival de otro, porque solo importa que vaya por delante). `node --check` OK. `sendPushNotification` degrada sin VAPID.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_