### PR TITLE
feat(retention): winback pushes at day 3/7/14 of inactivity

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -45,6 +45,7 @@ import { authenticate } from './middleware.js';
 import cron from 'node-cron';
 import { runStreakReminders } from './utils/streakReminders.js';
 import { runReferralReminders } from './utils/referralReminders.js';
+import { runWinbackReminders } from './utils/winbackReminders.js';
 import { autoFinishExpiredFights } from './utils/pvp_cleanup.js';
 import { sweepExpiredPacts } from './utils/campaignQuests.js';
 
@@ -61,6 +62,13 @@ if (process.env.VERCEL !== '1') {
     runStreakReminders()
       .then(count => console.log(`[CRON] Recordatorios enviados: ${count}`))
       .catch(err => console.error('[CRON] Error en recordatorios:', err));
+  });
+  // Winback pushes for lapsed users at day 3/7/14 of inactivity, daily at 17:00.
+  cron.schedule('0 17 * * *', () => {
+    console.log('[CRON] Iniciando winback D3/D7/D14...');
+    runWinbackReminders()
+      .then(count => console.log(`[CRON] Winback enviados: ${count}`))
+      .catch(err => console.error('[CRON] Error en winback:', err));
   });
   // Referral reminder every 15 days at 12:00 (days 1 and 16 of each month)
   cron.schedule('0 12 1,16 * *', () => {

--- a/backend/utils/winbackReminders.js
+++ b/backend/utils/winbackReminders.js
@@ -1,0 +1,88 @@
+import { query } from '../db.js';
+import { sendPushNotification } from './pushNotifications.js';
+
+/**
+ * Winback pushes for lapsed users, at day 3 / 7 / 14 of inactivity.
+ *
+ * Today a user who misses a single day gets nothing ever again (D30 ≈ 3-8%).
+ * This nudges them back with THEIR real data: the streak they had when they
+ * stopped (computed via gaps-and-islands over their rep dates), falling back to
+ * lifetime reps.
+ *
+ * Fires once a day (cron). A user hits each milestone exactly once because the
+ * cron runs daily and the query targets `days_inactive IN (3,7,14)` — the day
+ * the count equals 3, then 7, then 14. Users who never logged a rep are
+ * excluded (no history to hook onto — winback is for people who engaged once).
+ */
+const WINBACK_STAGES = [3, 7, 14];
+
+function buildMessage(name, stage, prevStreak, totalReps) {
+  const who = name || 'Atleta';
+  const streakHook = prevStreak >= 2;
+  if (stage === 3) {
+    return streakHook
+      ? `${who}, hace 3 días que no entrenas. Tenías una racha de ${prevStreak} días — aún estás a tiempo de retomarla. 💪`
+      : `${who}, hace 3 días que no entrenas. Una serie corta y vuelves al ruedo. 💪`;
+  }
+  if (stage === 7) {
+    return `${who}, una semana sin entrenar. Tus ${totalReps} reps en Reppy te esperan. ¡Vuelve a la barra!`;
+  }
+  // stage 14
+  return streakHook
+    ? `${who}, dos semanas fuera. Tu yo de ${prevStreak} días de racha no se rendiría. Vuelve hoy.`
+    : `${who}, dos semanas fuera. Un último empujón: retoma tu entrenamiento hoy.`;
+}
+
+// Length of the consecutive-day island that ends on the user's most recent rep
+// date = the streak they had when they stopped training.
+async function streakBeforeBreak(userId) {
+  const res = await query(
+    `WITH d AS (SELECT DISTINCT date FROM reps WHERE user_id = $1),
+          grp AS (
+            SELECT date,
+                   date - (ROW_NUMBER() OVER (ORDER BY date))::int * INTERVAL '1 day' AS island
+            FROM d
+          )
+     SELECT COUNT(*)::int AS streak
+     FROM grp
+     WHERE island = (SELECT island FROM grp ORDER BY date DESC LIMIT 1)`,
+    [userId]
+  );
+  return res.rows[0]?.streak || 0;
+}
+
+export async function runWinbackReminders() {
+  try {
+    const result = await query(
+      `SELECT ps.user_id, u.name, u.total_reps,
+              (CURRENT_DATE - MAX(r.date))::int AS days_inactive
+       FROM push_subscriptions ps
+       JOIN users u ON ps.user_id = u.id
+       JOIN reps r ON r.user_id = u.id
+       WHERE COALESCE(u.push_disabled, false) = false
+       GROUP BY ps.user_id, u.name, u.total_reps
+       HAVING (CURRENT_DATE - MAX(r.date))::int = ANY($1)`,
+      [WINBACK_STAGES]
+    );
+
+    console.log(`[WINBACK] Elegibles: ${result.rows.length} usuarios (D3/D7/D14).`);
+    let sentCount = 0;
+
+    for (const row of result.rows) {
+      const stage = row.days_inactive;
+      const prevStreak = await streakBeforeBreak(row.user_id);
+      await sendPushNotification(row.user_id, {
+        title: '¿Te has perdido? 🏋️',
+        body: buildMessage(row.name, stage, prevStreak, row.total_reps || 0),
+        data: { url: '/dashboard?log=1', type: 'WINBACK', stage },
+      });
+      sentCount += 1;
+    }
+
+    console.log(`[WINBACK] Enviadas ${sentCount} notificaciones.`);
+    return sentCount;
+  } catch (error) {
+    console.error('[WINBACK] Error:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Qué

Task P1-Retención: **Winback cron D3/D7/D14** — *"el mayor ROI de toda la auditoría"*. Hoy un usuario que falla un día no recibe nada nunca más (D30 ≈ 3-8%).

## Cambios

- **`backend/utils/winbackReminders.js`** (nuevo) — `runWinbackReminders()`: notifica a usuarios inactivos **exactamente 3, 7 o 14 días** con **su dato real**: la racha que tenían cuando pararon (calculada con gaps-and-islands sobre las fechas de sus reps), con fallback a reps totales. Reutiliza la infra de push de `streakReminders.js`.
- **`backend/index.js`** — cron diario a las 17:00.

Solo usuarios con push activado y con historial de reps (los que nunca registraron nada se excluyen — el winback engancha con "tenías racha de N"). Cada usuario alcanza cada hito una sola vez porque el cron corre a diario y la query filtra `days_inactive IN (3,7,14)`.

## Verificación — **integración local** (Postgres efímero)

7 usuarios cubriendo cada rama:

```
[WINBACK] Elegibles: 3 usuarios (D3/D7/D14)
eligible: wb3(D3), wb7(D7), wb14(D14)
NO: wb_active(hoy), wb2(2 días), wb_never(sin reps), wb_pushoff(push off)

racha-antes-de-parar (gaps-and-islands): wb3=5, wb7=12, wb14=1
```

La racha previa se calcula exacta (coincide con los días consecutivos sembrados). El caso `wb14` con racha=1 usa la copia de fallback (evita "racha de 1 día"). `node --check` OK. `sendPushNotification` degrada sin VAPID.

## Nota
Sin columna de dedupe: se apoya en el cron diario + hitos exactos (mismo patrón que los crons de racha/referral existentes). Si Roman prefiere garantía dura contra reenvíos, se puede añadir un `last_winback_stage` en un follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_