### PR TITLE
fix(social): validate page in /feed (400 instead of 500)

### DIFF
--- a/backend/social_feed.js
+++ b/backend/social_feed.js
@@ -315,7 +315,13 @@ router.get('/personal-insight', authenticate, async (req, res) => {
 router.get('/feed', optionalAuthenticate, async (req, res) => {
   const { filter = 'global', page = 1 } = req.query;
   const limit = 10;
-  const offset = (page - 1) * limit;
+  // A non-numeric/invalid `page` used to produce OFFSET NaN and a 500. Validate
+  // to a positive integer and return 400 for bad input instead.
+  const pageNum = Number(page);
+  if (!Number.isInteger(pageNum) || pageNum < 1) {
+    return res.status(400).json({ message: 'Invalid page' });
+  }
+  const offset = (pageNum - 1) * limit;
   const userId = req.user?.id || null;
   
   // Kick off expired-fight cleanup in the background (throttled, never awaited)


### PR DESCRIPTION
## Qué

Task P3-Deuda técnica: **`social_feed.js:318`** — `page` no numérico → 500 en vez de 400.

Un `page` no numérico/no positivo producía `OFFSET NaN` → error de Postgres → 500. Ahora se valida a entero positivo y se devuelve 400 ante entrada inválida.

## Verificación — **integración local** (Postgres efímero)

```
page=abc  -> 400   page=0   -> 400   page=-3 -> 400   page=1.5 -> 400
page=1/2/(sin page) -> pasan la validación
```

> Los `page` válidos devuelven 500 **solo** en el sandbox porque a la BD efímera le falta una relación de la query del feed (`parse_relation.c`, en `social_feed.js:350`, deriva de esquema ajena a este cambio). La validación se ejecuta **antes** de la query, así que el 400 queda probado con exactitud y los `page` válidos la atraviesan. `node --check` OK.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xbiv858QnxSr5e5nHdXBhv)_