### PR TITLE
fix(seo): drop keyword-stuffed noscript + meta keywords from index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,6 @@
     <title>Contador de Dominadas Gratis · App Calistenia RPG | Reppy</title>
     <meta name="title" content="Contador de Dominadas Gratis · App Calistenia RPG | Reppy" />
     <meta name="description" content="Registra dominadas, flexiones y fondos. Sube de nivel, gana Reppy Coins, derrota bosses y compite en rankings globales. App de calistenia gratis, sin anuncios." />
-    <meta name="keywords" content="reppy, contador de dominadas, pull-up tracker, contador de flexiones, pushup counter, calistenia app, fitness tracker, workout tracker, ejercicios calistenia, dominadas tracker, flexiones tracker, fondos tracker, muscle ups, repeticiones, entrenamiento cuerpo libre, bodyweight training, fitness gamificado, RPG fitness, contador repeticiones, racha ejercicio, heatmap entrenamiento, leaderboard fitness, ranking dominadas, app dominadas gratis, tracker calistenia gratis, registrar dominadas, registrar flexiones, entrenamiento sin pesas, street workout, barras, pull up counter, chin ups, dips counter, weighted pull ups, calisthenics tracker, rep counter, workout log, fitness app free, gym tracker, exercise counter, calistenia principiantes, rutina dominadas, challenge dominadas, reto fitness" />
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
     <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
     <meta name="bingbot" content="index, follow" />
@@ -172,62 +171,6 @@
 
   </head>
   <body>
-    <!-- ═══════════════════════════════════════════════════════════════
-         NOSCRIPT FALLBACK — SEO-visible content for crawlers
-    ═══════════════════════════════════════════════════════════════ -->
-    <noscript>
-      <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#1a1a2e;">
-        
-        <h2>🏋️ Tracker de Calistenia con Sistema RPG</h2>
-        <p>Cada repetición que registras te da <strong>Reppy Coins</strong> y te hace subir de nivel en 4 atributos: Fuerza (STR), Potencia (PWR), Resistencia (END) y Agilidad (AGI). Compra títulos, marcos y efectos en la tienda.</p>
-        
-        <h2>📊 Contador de Repeticiones con Estadísticas</h2>
-        <ul>
-          <li><strong>Heatmap de actividad</strong> estilo GitHub para visualizar tu constancia</li>
-          <li><strong>Rankings globales</strong> en tiempo real</li>
-          <li><strong>Racha de entrenamiento</strong> para mantener la motivación</li>
-          <li><strong>Progreso diario</strong> con metas personalizadas</li>
-          <li><strong>Historial completo</strong> de todas tus repeticiones</li>
-        </ul>
-        <div style="padding: 40px; text-align: center; font-family: sans-serif;">
-            <h2>Contador de Dominadas y Calistenia Gratis – Reppy</h2>
-            <p>Reppy es la mejor herramienta gratuita para registrar tus <strong>dominadas</strong>, <strong>flexiones</strong>, <strong>fondos</strong> y <strong>muscle ups</strong> con sistema RPG. Gana experiencia, compite en rankings y derrota bosses con la comunidad de calistenia.</p>
-            
-            <h2>¿Para qué sirve un contador de dominadas?</h2>
-            <p>Un contador de dominadas permite llevar el registro de tu volumen total de entrenamiento, esencial para la sobrecarga progresiva en calistenia y street workout.</p>
-
-            <h2>Funciones de Reppy:</h2>
-            <ul>
-                <li><strong>Contador de Dominadas:</strong> Registra tus pull-ups diarias.</li>
-                <li><strong>Contador de Flexiones:</strong> Trackea tus push-ups y mejora tu fuerza.</li>
-                <li><strong>Sistema RPG:</strong> Sube de nivel tus atributos STR, PWR, END y AGI.</li>
-                <li><strong>Rankings:</strong> Compite contra atletas de todo el mundo.</li>
-                <li><strong>Boss Fights:</strong> Únete a la caza de bosses comunitarios gratis.</li>
-            </ul>
-
-            <p>Empieza ahora gratis en reppy.romandev.app</p>
-        </div>
-
-        <h2>👹 Boss Fights Comunitarios</h2>
-        <p>Participa en eventos globales donde la comunidad lucha contra bosses épicos. Tus repeticiones infligen daño al boss. Derrótalo y desbloquea cofres con recompensas exclusivas.</p>
-
-        <h2>🎯 Ejercicios que puedes registrar</h2>
-        <ul>
-          <li>Dominadas (Pull-ups)</li>
-          <li>Flexiones (Push-ups)</li>
-          <li>Fondos (Dips)</li>
-          <li>Muscle Ups</li>
-          <li>Dominadas con lastre (Weighted Pull-ups)</li>
-        </ul>
-
-        <h2>🤝 Comunidad y Social</h2>
-        <p>Añade amigos, compara rankings, visita perfiles públicos y compite por el Top 1 en la clasificación global. Disponible en español e inglés.</p>
-
-        <p><strong>¡Empieza gratis!</strong> Solo necesitas una cuenta de Google para comenzar a trackear tu entrenamiento de calistenia.</p>
-        
-        <p>Para usar Reppy necesitas tener JavaScript habilitado en tu navegador.</p>
-      </div>
-    </noscript>
 
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>


### PR DESCRIPTION
Parte del bloque P2 SEO del fichero de auditoría. Quita del `frontend/index.html`:
- El bloque `<noscript>` SEO keyword-stuffed (~55 líneas) — redundante ahora que vite-ssg prerenderiza contenido real por ruta.
- El `<meta name=keywords>` con ~45 términos (Google lo ignora; posible señal de spam).

Conserva el `<noscript>` legítimo de fallback de fuentes.

**Verificación:** revisión estructural del HTML (body/head bien formados). No corrí el build vite-ssg completo en local — conviene un build antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)