### PR TITLE
fix(economy): close race conditions in /daily/refresh and referral reward

### DIFF
--- a/backend/reps.js
+++ b/backend/reps.js
@@ -238,15 +238,24 @@ router.post('/', authenticate, repsLimiter, async (req, res) => {
     // Recalculate stats after commit (Aggregated Truth)
     await recalculateUserStats(userId);
 
-    // Referral reward: give referrer +50 gems on referred user's first reps
+    // Referral reward: give referrer +50 gems on referred user's first reps.
+    // ATOMIC CLAIM GATE — flip referral_reward_given FALSE->TRUE and read
+    // referred_by in a single guarded UPDATE ... RETURNING. Postgres holds the
+    // row lock for the duration of the UPDATE, so concurrent "first reps" of the
+    // same user serialize and only ONE matches the row; losers get rowCount 0 and
+    // pay nothing. The previous version read the flag with one query() and set it
+    // with another, so two concurrent requests could both observe FALSE and pay
+    // the referrer twice. Same shape as shop.js /daily/claim.
     try {
-      const refRes = await query(
-        'SELECT referred_by FROM users WHERE id = $1 AND referral_reward_given = FALSE AND referred_by IS NOT NULL',
+      const claimRes = await query(
+        `UPDATE users
+         SET referral_reward_given = TRUE
+         WHERE id = $1 AND referral_reward_given = FALSE AND referred_by IS NOT NULL
+         RETURNING referred_by`,
         [userId]
       );
-      if (refRes.rows[0]) {
-        const referrerId = refRes.rows[0].referred_by;
-        await query('UPDATE users SET referral_reward_given = TRUE WHERE id = $1', [userId]);
+      if (claimRes.rows[0]) {
+        const referrerId = claimRes.rows[0].referred_by;
         await query('UPDATE users SET reppy_gems = reppy_gems + 50 WHERE id = $1', [referrerId]);
         await query(
           "INSERT INTO gem_transactions (user_id, amount, source, description) VALUES ($1, 50, 'referral_activated', 'Bonus por referido activado')",

--- a/backend/shop.js
+++ b/backend/shop.js
@@ -255,27 +255,53 @@ router.get('/daily', authenticate, async (req, res) => {
 router.post('/daily/refresh', authenticate, async (req, res) => {
   try {
     const userId = req.user.id;
-    const userRes = await query('SELECT reppy_gems, daily_refreshes, last_refresh_at FROM users WHERE id = $1', [userId]);
-    const user = userRes.rows[0];
-    
-    let currentRefreshes = user.daily_refreshes || 0;
-    const lastRefresh = new Date(user.last_refresh_at);
-    const today = new Date();
-    
-    if (lastRefresh.toDateString() !== today.toDateString()) {
-      currentRefreshes = 0;
+
+    // Lock the user row so the gem check, the escalating-cost calc and the
+    // deduction all happen atomically. The previous version read gems with a
+    // bare query(), checked, then deducted on a *different* pooled connection,
+    // so two concurrent refreshes could both pass the check, both refresh at the
+    // same (un-escalated) cost, and drive reppy_gems negative. Same pattern as
+    // roulette.js /buy-and-spin.
+    const result = await withTransaction(async (client) => {
+      const lockRes = await client.query(
+        'SELECT reppy_gems, daily_refreshes, last_refresh_at FROM users WHERE id = $1 FOR UPDATE',
+        [userId]
+      );
+      if (lockRes.rowCount === 0) return { status: 404, body: { message: 'User not found' } };
+      const user = lockRes.rows[0];
+
+      // Refresh counter resets on a new calendar day (same rule as before).
+      let currentRefreshes = user.daily_refreshes || 0;
+      if (user.last_refresh_at) {
+        const lastRefresh = new Date(user.last_refresh_at).toDateString();
+        if (lastRefresh !== new Date().toDateString()) currentRefreshes = 0;
+      }
+
+      const cost = currentRefreshes + 1;
+
+      if (user.reppy_gems < cost) {
+        return { status: 400, body: { message: 'INSUFFICIENT GEMS FOR REFRESH' } };
+      }
+
+      // Guarded deduction — cannot drive gems negative even under a race.
+      const deductRes = await client.query(
+        'UPDATE users SET reppy_gems = reppy_gems - $1, daily_refreshes = $2, last_refresh_at = CURRENT_TIMESTAMP WHERE id = $3 AND reppy_gems >= $1 RETURNING reppy_gems',
+        [cost, currentRefreshes + 1, userId]
+      );
+      if (deductRes.rowCount === 0) throw new Error('Insufficient gems at deduction time');
+
+      return { status: 200, body: { message: 'Shop refreshed', remaining_gems: deductRes.rows[0].reppy_gems } };
+    });
+
+    if (result.status !== 200) {
+      return res.status(result.status).json(result.body);
     }
 
-    const cost = currentRefreshes + 1;
-    
-    if (user.reppy_gems < cost) {
-      return res.status(400).json({ message: 'INSUFFICIENT GEMS FOR REFRESH' });
-    }
-
-    await query('UPDATE users SET reppy_gems = reppy_gems - $1, daily_refreshes = $2, last_refresh_at = CURRENT_TIMESTAMP WHERE id = $3', [cost, currentRefreshes + 1, userId]);
+    // Rotate outside the money transaction — it manages its own writes and is
+    // not part of the atomic gem deduction.
     await rotateDailyShop(userId);
 
-    res.json({ message: 'Shop refreshed', remaining_gems: user.reppy_gems - cost });
+    res.json(result.body);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
Cierra las dos race conditions restantes de la sección **P3 — Deuda técnica** (`docs/auditoria-2026-07-tasks.md`): `backend/shop.js` `/daily/refresh` (sin transacción ni guard de gemas) y `backend/reps.js` referral (pagable 2 veces). El patrón correcto ya vivía en `roulette.js` / `shop.js` `/daily/claim`; esto los pone al mismo nivel.

## Problema

Dos bugs TOCTOU permitían a peticiones concurrentes corromper la economía de gemas:

1. **`POST /shop/daily/refresh`** — leía `reppy_gems` con un `query()` suelto, comprobaba `gems < cost`, y luego deducía con **otra** conexión del pool. Dos refresh concurrentes podían **ambos** pasar el check, **ambos** refrescar al mismo coste sin escalar, y dejar `reppy_gems` **en negativo**.
2. **Referral reward en `POST /reps`** — leía `referral_reward_given` con un `query()` y lo ponía a `TRUE` con otro. Dos "primeras reps" concurrentes del mismo referido podían **ambas** ver `FALSE` y pagar al referidor **50 gemas dos veces** (o N veces).

## Solución

- `/daily/refresh`: envuelto en `withTransaction` + `SELECT ... FOR UPDATE` sobre la fila del usuario; el cálculo de coste escalado y la deducción guardada (`... AND reppy_gems >= $1 RETURNING`) ocurren bajo el lock. Idéntico patrón que `roulette.js` `/buy-and-spin`. `rotateDailyShop()` se queda **fuera** de la transacción de dinero (gestiona sus propias escrituras y no es parte de la atomicidad).
- Referral: sustituido el read-then-write por una **claim gate atómica** — un único `UPDATE users SET referral_reward_given = TRUE WHERE ... referral_reward_given = FALSE ... RETURNING referred_by`. Postgres mantiene el row lock durante el UPDATE, así que las concurrentes se serializan y **solo una** matchea la fila; las perdedoras dan `rowCount 0` y no pagan nada. Misma forma que la gate de `/daily/claim`.

No añado un log en `gem_transactions` para el gasto del refresh (el código original tampoco lo tenía) para mantener el scope acotado al fix de concurrencia.

## Verificación — `integración local`

Levanté un **PostgreSQL 16 efímero** en el sandbox, cargué `backend/schema.sql`, añadí las columnas que solo viven en `/db/init` (`daily_refreshes`, `last_refresh_at` — el drift de esquema que la propia auditoría señala en P3) y ejercité el **SQL exacto** del fix con 20 peticiones concurrentes vía `Promise.all` sobre un pool `pg`. Resultado (6/6):

```
TEST 1 — Referral (NEW guarded gate):
  PASS exactly 1 concurrent claim won (got 1)
  PASS referrer paid exactly 50 gems (got 50)
  PASS exactly 1 gem_transaction logged
TEST 2 — Referral (OLD buggy) should DOUBLE-PAY:
  PASS OLD code overpays under race (got 1000 > 50)   ← test con dientes
TEST 3 — Daily refresh never goes negative (NEW guarded tx):
  PASS gems never negative after 20 concurrent refreshes (got 2)
TEST 4 — Daily refresh (OLD buggy) should overspend/negative:
  PASS OLD code drives gems negative under race (got -15 < 0)  ← test con dientes
```

Los dos tests "OLD" corren el SQL previo para demostrar que el test detecta el bug: sin el fix, el referidor cobra 1000 gemas (20×50) y las gemas del refresh caen a −15. Además `node --check` OK en ambos ficheros.

No pude ejercitar los endpoints HTTP completos end-to-end (el handler `POST /reps` arrastra bosses/misiones/campaña), pero el test valida la atomicidad a nivel SQL, que es exactamente el núcleo de ambos fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ths2E9upQ9zwZyaFdS5JTC)_