### PR TITLE
fix(seo): use English blog slugs in llms.txt /en/ URLs

### DIFF
--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -26,16 +26,16 @@
 
 ## Guides & training programs
 
-- [Pull-Up Program: 0 to 10 reps in 8 weeks](https://reppy.romandev.app/en/blog/programa-dominadas-8-semanas): Week-by-week pull-up program with progression tables, from first assisted rep to 10 clean reps.
-- [How to do your first pull-up](https://reppy.romandev.app/en/blog/guia-definitiva-dominadas): Beginner guide to achieving a first strict pull-up, including assisted progressions.
-- [How to do more pull-ups](https://reppy.romandev.app/en/blog/error-mas-dominadas): Break plateaus and increase your pull-up max — common mistakes and fixes.
-- [How to do your first push-up](https://reppy.romandev.app/en/blog/flexiones-perfectas-errores): Perfect push-up form, common errors, and step-by-step progression.
-- [Pike push-ups guide](https://reppy.romandev.app/en/blog/pike-push-ups-guia-definitiva): Technique, progressions and mistakes for pike push-ups toward the handstand push-up.
-- [Parallel-bar dips progression](https://reppy.romandev.app/en/blog/progresion-fondos-paralelas): Progression from beginner to advanced dips for chest and triceps strength.
-- [How to do your first muscle-up](https://reppy.romandev.app/en/blog/muscle-up-progresion-tecnica): The transition and explosive-power secrets behind a first muscle-up.
-- [7 best calisthenics shoulder exercises](https://reppy.romandev.app/en/blog/ejercicios-hombros-calistenia): Build shoulders with no weights using bodyweight exercises.
-- [Weekly calisthenics routine for beginners](https://reppy.romandev.app/en/blog/rutina-calistenia-semanal-principiantes): A complete beginner weekly training plan.
-- [How to start calisthenics from zero](https://reppy.romandev.app/en/blog/manual-inicio-calistenia): A beginner's manual for starting bodyweight training.
+- [Pull-Up Program: 0 to 10 reps in 8 weeks](https://reppy.romandev.app/en/blog/8-week-pull-up-program): Week-by-week pull-up program with progression tables, from first assisted rep to 10 clean reps.
+- [How to do your first pull-up](https://reppy.romandev.app/en/blog/ultimate-pull-up-guide): Beginner guide to achieving a first strict pull-up, including assisted progressions.
+- [How to do more pull-ups](https://reppy.romandev.app/en/blog/more-pull-ups-mistake): Break plateaus and increase your pull-up max — common mistakes and fixes.
+- [How to do your first push-up](https://reppy.romandev.app/en/blog/perfect-push-ups-mistakes): Perfect push-up form, common errors, and step-by-step progression.
+- [Pike push-ups guide](https://reppy.romandev.app/en/blog/pike-push-ups-ultimate-guide): Technique, progressions and mistakes for pike push-ups toward the handstand push-up.
+- [Parallel-bar dips progression](https://reppy.romandev.app/en/blog/dips-progression): Progression from beginner to advanced dips for chest and triceps strength.
+- [How to do your first muscle-up](https://reppy.romandev.app/en/blog/muscle-up-progression-technique): The transition and explosive-power secrets behind a first muscle-up.
+- [7 best calisthenics shoulder exercises](https://reppy.romandev.app/en/blog/calisthenics-shoulder-exercises): Build shoulders with no weights using bodyweight exercises.
+- [Weekly calisthenics routine for beginners](https://reppy.romandev.app/en/blog/beginner-weekly-calisthenics-routine): A complete beginner weekly training plan.
+- [How to start calisthenics from zero](https://reppy.romandev.app/en/blog/calisthenics-beginner-manual): A beginner's manual for starting bodyweight training.
 
 ## Spanish content
 


### PR DESCRIPTION
Task de **P2 — SEO fixes**: *"`llms.txt` con slugs ES bajo `/en/blog/` — `frontend/public/llms.txt:29-38`"*.

## Problema

La sección *"Guides & training programs"* (líneas 29-38) listaba los slugs **españoles** de cada post bajo URLs `/en/blog/`, p. ej. `https://reppy.romandev.app/en/blog/programa-dominadas-8-semanas`. Pero las rutas EN del blog se generan con `post.slugEn` (`frontend/vite.config.js:110` → `/en/blog/${post.slugEn || post.slug}`), así que los **10** enlaces apuntaban a rutas inglesas inexistentes. Un `llms.txt` cuya razón de ser es dar a los crawlers/LLMs URLs canónicas correctas, dándoles 10 rotas.

## Solución

Cada URL cambiada al `slugEn` real de `frontend/src/blogPosts.json` (fuente de verdad de las rutas):

| ES slug (antes, roto en /en/) | EN slug (ahora) |
|---|---|
| programa-dominadas-8-semanas | 8-week-pull-up-program |
| guia-definitiva-dominadas | ultimate-pull-up-guide |
| error-mas-dominadas | more-pull-ups-mistake |
| flexiones-perfectas-errores | perfect-push-ups-mistakes |
| pike-push-ups-guia-definitiva | pike-push-ups-ultimate-guide |
| progresion-fondos-paralelas | dips-progression |
| muscle-up-progresion-tecnica | muscle-up-progression-technique |
| ejercicios-hombros-calistenia | calisthenics-shoulder-exercises |
| rutina-calistenia-semanal-principiantes | beginner-weekly-calisthenics-routine |
| manual-inicio-calistenia | calisthenics-beginner-manual |

La sección *"Spanish content"* (línea 45) ya usaba el slug ES bajo `/es/`, que es correcto — no se toca.

## Verificación — `solo revisión lógica`

`llms.txt` es un asset estático de `public/` que se copia tal cual a `dist/` (no lo procesa Vite), así que no hay build que romper ni sintaxis que checar. Verifiqué:
- Los 10 `slugEn` salen directamente de `blogPosts.json` (44 posts) resolviendo cada `slug` ES → su `slugEn`; los 10 existen.
- El esquema de ruta coincide exactamente con el generador SSG: `vite.config.js:110` emite un route por cada `post.slugEn`, y en un build previo confirmé que `dist/en/blog/` contiene esos HTML (p. ej. `pike-push-ups-ultimate-guide.html`, `muscle-up-progression-technique.html`, `calisthenics-shoulder-exercises.html`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ths2E9upQ9zwZyaFdS5JTC)_