### PR TITLE
balance(streak): capar la recompensa de racha a 200 coins/día

### DIFF
--- a/backend/utils/stats.js
+++ b/backend/utils/stats.js
@@ -297,7 +297,12 @@ export const recalculateUserStats = async (userId, force = false) => {
     const lastRewardDate = user.last_streak_reward_date ? getLocalDateString(user.last_streak_reward_date) : null;
     
     if (streak > 0 && lastRewardDate !== todayStr) {
-      additionalCoins = streak * 50;
+      // Streak reward capped at 200 coins/day. Previously `streak * 50` grew
+      // unbounded, making "just keep the streak alive" dwarf actually training
+      // (auditoría 2026-07: ~85-90% del ingreso diario venía de abrir, no de
+      // entrenar). Base 50 + 5 por día de racha hasta un tope de 30 días:
+      //   streak 1 -> 55 · 10 -> 100 · 30+ -> 200 (cap).
+      additionalCoins = 50 + 5 * Math.min(streak, 30);
       newLastStreakRewardDate = todayStr;
 
       await createNotification(


### PR DESCRIPTION
## Qué

Task de `docs/auditoria-2026-07-tasks.md` (P1 — Rebalance económico): **"Cap a la recompensa de racha"** ✅DECIDIDO (2026-07-25: opción A).

`backend/utils/stats.js:300` daba `additionalCoins = streak * 50` **sin tope**, así que el ingreso por "mantener la racha viva" (= abrir la app) crecía sin límite y eclipsaba el ingreso por entrenar de verdad. La auditoría estimó que ~85-90% del ingreso diario de un jugador con racha venía de abrir, no de entrenar.

**Nueva fórmula:** `50 + 5 · min(streak, 30)` → tope **200 coins/día**.

| racha | nuevo | antiguo |
|---|---|---|
| 1 | 55 | 50 |
| 2 | 60 | 100 |
| 10 | 100 | 500 |
| 30 | 200 | 1500 |
| 31+ | 200 (cap) | 1550+ |

## Verificación de que no rompe otros cálculos (requerido por el task)

- **Único consumidor de la recompensa de racha en coins**: `stats.js:300`. Es un valor local (`additionalCoins`) que se suma a `reppy_coins` en el UPDATE final; el path de escritura a DB queda **idéntico** (mismo `if` guard, misma notificación dinámica, mismo UPDATE) — solo cambia el número.
- **`stats.js:196`** (`baseVigXP = streak*100 + varietyCount*50`) es un cálculo **distinto** (XP de VIG, no coins) → intacto.
- **Frontend**: no existe preview de la recompensa de racha (grep sin resultados); la notificación usa `additionalCoins` en runtime, así que sigue mostrando el valor correcto.
- **`backend/scripts/analyze_economy_curves.js`** (documenta `streak * 50` UNCAPPED): **se deja intacto a propósito** — es el snapshot de análisis que justificó esta decisión; reescribirlo sería falsear la evidencia.

## Verificación

Nivel: **build/sintaxis + revisión lógica** (no se levantó Postgres: el cambio es una sustitución aritmética pura y el path de escritura a DB es byte-idéntico al anterior, por lo que un test de integración no añade seguridad sobre la tabla de valores ya verificada).

- `node --check backend/utils/stats.js` OK.
- Tabla de valores verificada con `node -e` (ver tabla arriba): monótona y capada en 200.
- Suite pura de economía (`node --test tests/economy-math.test.mjs`) verde (5/5) — sin regresiones.
- No añado test unitario del cap porque la fórmula vive inline dentro de `updateStats` (función con DB); extraerla a un helper puro sería un refactor oportunista fuera de scope (🧊).

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_