### PR TITLE
balance(fe): nerfar el bono plano divino de FTH (×25 → ×5) — Parte A de "Domar la bola de nieve de FE"

### DIFF
--- a/backend/utils/damage.js
+++ b/backend/utils/damage.js
@@ -70,7 +70,11 @@ export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false
 
   // Divine Scaling (FTH)
   const fthScale = 1 + (fthLvl / 40);
-  const divineBonus = fthLvl * 25; // FLAT bonus, applied per rep
+  // Flat divine bonus, applied per rep. Nerfed 25 -> 5 (auditoría 2026-07) to
+  // tame the damage->FTH->damage snowball: FTH XP comes from boss damage dealt,
+  // so a big flat FTH bonus fed back into ever-larger hits. `fthScale` (the
+  // multiplicative part) is untouched.
+  const divineBonus = fthLvl * 5;
 
   // --- BASE DAMAGE per rep (No gear, no buffs) ---
   const baseStatStr = parseInt(user.base_str_lvl) || strLvl;
@@ -78,7 +82,7 @@ export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false
   const baseStatFth = parseInt(user.base_fth_lvl) || fthLvl;
 
   const baseScale = (1 + (baseStatStr / 25)) * (1 + (baseStatEnd / 50)) * (1 + (baseStatFth / 40));
-  const baseDivine = baseStatFth * 25; // FLAT bonus, applied per rep
+  const baseDivine = baseStatFth * 5; // FLAT bonus, applied per rep (nerfed 25 -> 5, see above)
   const perRepBaseNoCrit = (perRepDamageValue * levelMult * intBonus * chaBonus * baseScale) + baseDivine;
 
   // --- DAMAGE WITH GEAR per rep (No potions) ---


### PR DESCRIPTION
## Qué

Task de `docs/auditoria-2026-07-tasks.md` (P1): **"Domar la bola de nieve de FE"** ✅DECIDIDO (2026-07-25: opción A+C). Esta PR implementa **solo la Parte A** (el nerf del bono plano). **La Parte C se aparca por una consecuencia grave descubierta al leer el código — ver abajo.**

### Parte A (implementada aquí)

`backend/utils/damage.js`: el bono plano `divineBonus = fthLvl * 25` (y su gemelo `baseDivine = baseStatFth * 25` del desglose de daño base) → **× 5**. La XP de FTH sale del daño infligido a bosses, así que un bono plano grande por nivel de FTH realimentaba la bola de nieve daño→FTH→daño. Se baja el término **plano**; el multiplicativo `fthScale = 1 + fthLvl/40` queda intacto.

Ejemplo (fth_lvl 30): `divineBonus` 750 → 150.

## Parte C: APARCADA — requiere decisión de Roman ⚠️

La Parte C pedía mover la fuente de XP de FTH de "daño infligido" a "participación en raids/quests (definir la nueva fuente al implementar)". **Al leer el código, esa fuente NO está aislada:**

- `stats.js:193` `fthXP = floor(total_dmg / 50)` alimenta `rawTotalXP` (`stats.js:235`) → `totalXP` → **`newLevel` (nivel global del personaje)** (`stats.js:240-241`).
- `recalculateUserStats` recomputa desde el historial absoluto y **permite que el nivel BAJE**.
- ⇒ Cambiar la fuente de FTH a un número de "participación" (mucho menor que `daño/50` para veteranos) **reduciría el `total_xp` y DESNIVELARÍA retroactivamente a todos los usuarios** en su siguiente log de reps. El nivel global además realimenta el daño (`levelMult = 1 + glvl/2`), leaderboards, etc.

Esto no estaba contemplado en la decisión ("definir la nueva fuente al implementar" no menciona el reseteo de nivel). Es una decisión de producto, no un detalle de implementación → **no lo implemento a ciegas**. He dejado un `⏸️` en el fichero de tasks con opciones y recomendación.

## Verificación

Nivel: **sintaxis + revisión lógica + smoke test de la función** (cambio numérico puro en la fórmula de daño; sin DB ni endpoints nuevos).

- `node --check backend/utils/damage.js` OK.
- Smoke test: `calculateDamage()` corre y produce el bono nerfeado (750→150 para fth_lvl 30).
- Ningún test de backend referencia `calculateDamage`/`divine`/`fth` → sin regresiones en CI.
- La descripción i18n de FTH ("Community/Faith · Total Boss Damage") sigue siendo correcta porque la Parte A **no** cambia la fuente de FTH.

⚠️ `PR revisable, no auto-merge` (así lo pide el task).

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_