### PR TITLE
feat(streak): "Día de descanso activo" — preservar la racha gratis 1×/semana

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -239,9 +239,14 @@ CREATE TABLE IF NOT EXISTS streak_freezes (
     user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
     freeze_date DATE NOT NULL,
     spent_coins INTEGER NOT NULL DEFAULT 250,
+    -- TRUE = free weekly "rest day" (día de descanso activo); FALSE = paid 250-coin freeze.
+    -- Tracked apart so the rest-day weekly limit never touches the paid-freeze economy.
+    is_rest_day BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(user_id, freeze_date)
 );
+-- Idempotent migration for existing DBs (the CREATE above only helps fresh ones).
+ALTER TABLE streak_freezes ADD COLUMN IF NOT EXISTS is_rest_day BOOLEAN DEFAULT FALSE;
 
 -- Index for better performance
 CREATE INDEX IF NOT EXISTS idx_reps_user_date ON reps(user_id, date);

--- a/backend/streak.js
+++ b/backend/streak.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { authenticate } from './middleware.js';
-import { freezeStreakForToday, getStreakStatus } from './utils/streak.js';
+import { freezeStreakForToday, useRestDayForToday, getStreakStatus } from './utils/streak.js';
 
 const router = express.Router();
 
@@ -21,6 +21,17 @@ router.post('/freeze', authenticate, async (req, res) => {
   } catch (error) {
     console.error('Error freezing streak:', error);
     res.status(error.status || 500).json({ message: error.message || 'Error freezing streak' });
+  }
+});
+
+// Día de descanso activo: preserve the streak for free, 1×/week.
+router.post('/rest-day', authenticate, async (req, res) => {
+  try {
+    const status = await useRestDayForToday(req.user.id);
+    res.json(status);
+  } catch (error) {
+    console.error('Error using rest day:', error);
+    res.status(error.status || 500).json({ message: error.message || 'Error using rest day' });
   }
 });
 

--- a/backend/utils/streak.js
+++ b/backend/utils/streak.js
@@ -3,6 +3,9 @@ import { getLocalDateString } from './date.js';
 
 export const STREAK_FREEZE_COST = 250;
 export const STREAK_FREEZE_WEEKLY_LIMIT = 1;
+// "Día de descanso activo": 1 free streak-preserving rest per week, tracked
+// apart from the paid freeze so it never consumes the 250-coin freeze allowance.
+export const REST_DAY_WEEKLY_LIMIT = 1;
 export const STREAK_RISK_HOUR_THRESHOLD = 6;
 export const JACKPOT_DAYS_REQUIRED = 5;   // days/7 needed to trigger jackpot
 export const JACKPOT_REWARD_COINS = 75;   // RC bonus
@@ -19,6 +22,8 @@ export const ensureStreakFreezeTable = async (q = defaultQuery) => {
     )
   `);
   await q('CREATE INDEX IF NOT EXISTS idx_streak_freezes_user_date ON streak_freezes(user_id, freeze_date)');
+  // Distinguishes the free weekly rest day from the paid 250-coin freeze.
+  await q('ALTER TABLE streak_freezes ADD COLUMN IF NOT EXISTS is_rest_day BOOLEAN DEFAULT FALSE');
 };
 
 const addDays = (date, amount) => {
@@ -67,10 +72,13 @@ export const getStreakStatus = async (userId, q = defaultQuery) => {
   const yesterday = getLocalDateString(addDays(new Date(), -1));
   const weekStart = getLocalDateString(getStartOfWeek());
 
-  const [activityRes, freezeRes, weekFreezeRes, userRes, weeklyProgressRes] = await Promise.all([
+  const [activityRes, freezeRes, weekFreezeRes, restWeekRes, userRes, weeklyProgressRes] = await Promise.all([
     q('SELECT DISTINCT date FROM reps WHERE user_id = $1 AND count > 0', [userId]),
     q('SELECT freeze_date FROM streak_freezes WHERE user_id = $1', [userId]),
-    q('SELECT COUNT(*)::int AS count FROM streak_freezes WHERE user_id = $1 AND freeze_date >= $2', [userId, weekStart]),
+    // Paid freezes only — rest days must NOT consume the paid-freeze weekly allowance.
+    q('SELECT COUNT(*)::int AS count FROM streak_freezes WHERE user_id = $1 AND freeze_date >= $2 AND is_rest_day = FALSE', [userId, weekStart]),
+    // Free rest days used this week (separate weekly limit).
+    q('SELECT COUNT(*)::int AS count FROM streak_freezes WHERE user_id = $1 AND freeze_date >= $2 AND is_rest_day = TRUE', [userId, weekStart]),
     q('SELECT reppy_coins, last_jackpot_week FROM users WHERE id = $1', [userId]),
     // Count unique active days this week (reps OR freezes)
     q(`SELECT COUNT(DISTINCT active_date)::int AS count FROM (
@@ -92,6 +100,7 @@ export const getStreakStatus = async (userId, q = defaultQuery) => {
   const streak = countCurrentStreak(activeDates);
   const hoursLeftToday = getHoursLeftToday();
   const freezesThisWeek = Number(weekFreezeRes.rows[0]?.count || 0);
+  const restDaysThisWeek = Number(restWeekRes.rows[0]?.count || 0);
   const coins = Number(userRes.rows[0]?.reppy_coins || 0);
   const isAtRisk = !activeToday && activeDates.has(yesterday);
 
@@ -119,6 +128,10 @@ export const getStreakStatus = async (userId, q = defaultQuery) => {
     freezesThisWeek,
     weeklyFreezeLimit: STREAK_FREEZE_WEEKLY_LIMIT,
     canFreeze: isAtRisk && freezesThisWeek < STREAK_FREEZE_WEEKLY_LIMIT && coins >= STREAK_FREEZE_COST,
+    // Free weekly rest day: preserves the streak at no coin cost, 1×/week.
+    restDaysThisWeek,
+    restDayWeeklyLimit: REST_DAY_WEEKLY_LIMIT,
+    canUseRestDay: isAtRisk && restDaysThisWeek < REST_DAY_WEEKLY_LIMIT,
     coins,
     weeklyProgress,
     jackpotDaysRequired: JACKPOT_DAYS_REQUIRED,
@@ -176,4 +189,51 @@ export const freezeStreakForToday = async (userId) => {
   } finally {
     client.release();
   }
+};
+
+/**
+ * "Día de descanso activo": preserve today's streak for free, once per week.
+ * Costs no coins and draws from a separate weekly allowance
+ * (REST_DAY_WEEKLY_LIMIT), so it never touches the paid-freeze economy. Only
+ * usable when the streak is actually at risk (didn't train today).
+ *
+ * Unlike freezeStreakForToday there is no coin deduction, so no multi-statement
+ * transaction is needed: the single guarded INSERT is atomic on its own and the
+ * UNIQUE(user_id, freeze_date) constraint makes concurrent same-day requests
+ * race-safe (the loser hits ON CONFLICT and gets rowCount 0). This deliberately
+ * avoids opening a FOR UPDATE transaction around getStreakStatus, which would
+ * dead-lock: getStreakStatus issues an `ALTER TABLE users ... IF NOT EXISTS` on
+ * a separate pooled connection, and that ALTER takes ACCESS EXCLUSIVE even as a
+ * no-op — conflicting with a held FOR UPDATE row lock.
+ */
+export const useRestDayForToday = async (userId) => {
+  // Read-only status check, outside any transaction.
+  const status = await getStreakStatus(userId);
+  if (!status.isAtRisk) {
+    const error = new Error('Tu racha no está en riesgo ahora mismo.');
+    error.status = 400;
+    throw error;
+  }
+  if (status.restDaysThisWeek >= REST_DAY_WEEKLY_LIMIT) {
+    const error = new Error('Ya has usado tu día de descanso de esta semana.');
+    error.status = 400;
+    throw error;
+  }
+
+  // Free rest day: spent_coins = 0, is_rest_day = TRUE. The UNIQUE constraint on
+  // (user_id, freeze_date) means a concurrent duplicate (or an already-protected
+  // day) hits ON CONFLICT and returns 0 rows.
+  const insertRes = await defaultQuery(
+    `INSERT INTO streak_freezes (user_id, freeze_date, spent_coins, is_rest_day)
+     VALUES ($1, CURRENT_DATE, 0, TRUE)
+     ON CONFLICT (user_id, freeze_date) DO NOTHING`,
+    [userId]
+  );
+  if (insertRes.rowCount === 0) {
+    const error = new Error('Tu racha ya está protegida hoy.');
+    error.status = 400;
+    throw error;
+  }
+
+  return getStreakStatus(userId);
 };

--- a/frontend/src/components/pages/Dashboard.vue
+++ b/frontend/src/components/pages/Dashboard.vue
@@ -174,6 +174,16 @@
     >
       <Snowflake class="h-5 w-5 text-amber-400 shrink-0" aria-hidden="true" />
       <p class="flex-1 min-w-0 text-xs font-medium text-amber-300">{{ streakStateLabel }}</p>
+      <!-- Free weekly rest day: preferred CTA when still available this week. -->
+      <button
+        v-if="streakStatus.restDayWeeklyLimit && streakStatus.restDaysThisWeek < streakStatus.restDayWeeklyLimit"
+        type="button"
+        class="shrink-0 rounded-xl border border-emerald-500/50 bg-emerald-500/15 text-emerald-200 px-3 py-2 text-xs font-semibold disabled:opacity-40 active:scale-95 transition-transform"
+        :disabled="!streakStatus.canUseRestDay || usingRestDay"
+        @click="useRestDay"
+      >
+        {{ restDayButtonLabel }}
+      </button>
       <button
         type="button"
         class="shrink-0 rounded-xl border border-amber-500/50 bg-amber-500/15 text-amber-200 px-3 py-2 text-xs font-semibold disabled:opacity-40 active:scale-95 transition-transform"
@@ -836,6 +846,7 @@ const guidedTrainingStateLoaded = ref(false);
 const planPromoDismissed = ref(false);
 const streakStatus = ref(null);
 const freezingStreak = ref(false);
+const usingRestDay = ref(false);
 const QUICKSTART_SEEN_PREFIX = 'reppy_quickstart_seen_v1';
 const GOAL_ONBOARDING_DISMISSED_PREFIX = 'reppy_goal_onboarding_dismissed_v1';
 const PLAN_PROMO_DISMISSED_PREFIX = 'reppy_plan_promo_dismissed_v1';
@@ -1006,6 +1017,11 @@ const freezeButtonLabel = computed(() => {
   return i18n.t('streak_freeze_for', { cost });
 });
 
+const restDayButtonLabel = computed(() => {
+  if (usingRestDay.value) return i18n.t('streak_resting');
+  return i18n.t('streak_rest_day');
+});
+
 const maybeCelebrateStreak = async (status) => {
   if (typeof window === 'undefined' || !status?.trainedToday) return;
   const today = getLocalDateString();
@@ -1047,6 +1063,20 @@ const freezeStreak = async () => {
     notificationStore.notify(error.response?.data?.message || i18n.t('streak_freeze_error'), 'error');
   } finally {
     freezingStreak.value = false;
+  }
+};
+
+const useRestDay = async () => {
+  if (!streakStatus.value?.canUseRestDay || usingRestDay.value) return;
+  usingRestDay.value = true;
+  try {
+    const res = await axios.post('/api/streak/rest-day');
+    streakStatus.value = res.data;
+    notificationStore.notify(i18n.t('streak_rest_notify'), 'success');
+  } catch (error) {
+    notificationStore.notify(error.response?.data?.message || i18n.t('streak_rest_error'), 'error');
+  } finally {
+    usingRestDay.value = false;
   }
 };
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1352,6 +1352,10 @@ export default {
     streak_save_today: 'Save today',
     streak_frozen_notify: 'Streak frozen until tomorrow',
     streak_freeze_error: 'Could not freeze streak',
+    streak_rest_day: 'Free rest day',
+    streak_resting: 'Resting…',
+    streak_rest_notify: 'Streak protected with your weekly rest day',
+    streak_rest_error: 'Could not use rest day',
 
     // Companion (mobile/desktop overview)
     comp_level_short: 'Lv.',

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -1431,6 +1431,10 @@ export default {
     streak_save_today: 'Salvar hoy',
     streak_frozen_notify: 'Racha congelada hasta mañana',
     streak_freeze_error: 'No se pudo congelar la racha',
+    streak_rest_day: 'Descanso gratis',
+    streak_resting: 'Descansando…',
+    streak_rest_notify: 'Racha protegida con tu día de descanso semanal',
+    streak_rest_error: 'No se pudo usar el día de descanso',
 
     // Companion (resumen móvil/escritorio)
     comp_level_short: 'Nv.',


### PR DESCRIPTION
## Qué

Task de `docs/auditoria-2026-07-tasks.md` (P1 — Retención): **"Día de descanso activo"** ✅DECIDIDO (2026-07-25: opción A).

Un botón que **preserva la racha sin coste, 1×/semana**, con un cupo semanal **separado** del freeze de 250 coins (no toca su economía). Reutiliza la infra de `streak_freezes`: un descanso es una fila freeze con `spent_coins = 0` e `is_rest_day = TRUE`, así hereda automáticamente el marcado de "día activo" que preserva la racha.

## Cambios

**Backend**
- `schema.sql` + `ensureStreakFreezeTable`: nueva columna idempotente `streak_freezes.is_rest_day BOOLEAN DEFAULT FALSE`.
- `utils/streak.js`:
  - `getStreakStatus`: el cupo del **freeze de pago** ahora cuenta solo `is_rest_day = FALSE` (antes contaba todas las filas → un descanso habría consumido el cupo del freeze). Nuevos campos: `restDaysThisWeek`, `restDayWeeklyLimit`, `canUseRestDay`. Reset semanal vía `getStartOfWeek` (mismo criterio que el freeze).
  - `useRestDayForToday()` + constante `REST_DAY_WEEKLY_LIMIT = 1`.
- `streak.js`: `POST /api/streak/rest-day`.

**Frontend**
- `Dashboard.vue`: botón **"Descanso gratis"** en la alerta de racha en riesgo, como CTA preferente cuando queda descanso semanal; el freeze de 250 RC se mantiene como fallback. Sin `fetchProfile` (no hay cambio de monedas).
- i18n **es/en**: `streak_rest_day`, `streak_resting`, `streak_rest_notify`, `streak_rest_error`.

## Nota importante: deadlock pre-existente descubierto ⚠️

Al probar con Postgres real detecté un **deadlock latente pre-existente en `freezeStreakForToday`** (NO introducido por esta PR): abre una transacción con `SELECT … FOR UPDATE users` y dentro llama a `getStreakStatus`, que ejecuta `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_jackpot_week` en **otra** conexión del pool. En PG16 ese `ADD COLUMN IF NOT EXISTS` toma `ACCESS EXCLUSIVE` **aunque sea no-op**, y choca con el `FOR UPDATE` retenido; como la conexión de la transacción queda `idle in transaction`, el detector de deadlock de PG no lo ve y **cuelga indefinidamente** (verificado con `pg_stat_activity`).

Para el descanso **evité el patrón**: no hay monedas que descontar, así que no hace falta transacción multi-statement — hago la comprobación de estado (read-only, fuera de transacción) y luego un único `INSERT … ON CONFLICT DO NOTHING`, que es atómico por sí mismo y race-safe por el `UNIQUE(user_id, freeze_date)`. Así el descanso **no** hereda el deadlock del freeze. **El deadlock del freeze queda sin tocar (fuera de scope 🧊) — recomiendo abrir una task de deuda técnica para sacar el `ALTER` de `getStreakStatus` (o no correrlo dentro de txns con lock).**

## Verificación

Nivel: **integración local con Postgres efímero** (lo que pide el protocolo).

- `initdb` + arranque de Postgres 16 + carga de `backend/schema.sql` (limpio) + flujo real vía los módulos reales (`getStreakStatus`, `useRestDayForToday`):
  - Estado inicial (entrenó ayer, no hoy): `isAtRisk=true, streak=1, canUseRestDay=true, restDaysThisWeek=0, freezesThisWeek=0`.
  - Tras el descanso: `streak=2` (racha preservada), `restDaysThisWeek=1`, `canUseRestDay=false`, `frozenToday=true`, **`freezesThisWeek=0` (cupo de pago intacto)**.
  - Fila DB: `spent_coins=0`, `is_rest_day=true`. Monedas del usuario **sin cambio** (1000→1000).
  - 2º intento en la semana → rechazado.
- `node --check` OK en los `.js` de backend tocados.
- `npm run build` (frontend) OK, `check:i18n` → **"All locale files clean"**.

⚠️ PR revisable (cambia mecánica core de racha), no auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_