### PR TITLE
seo(sitemap): exponer solo atletas con ≥50 reps en /top-public

### DIFF
--- a/backend/profile.js
+++ b/backend/profile.js
@@ -101,9 +101,12 @@ router.get('/top-public', async (req, res) => {
   try {
     const limit = Math.min(parseInt(req.query.limit) || 100, 200);
     const result = await query(
+      // total_reps >= 50: only expose athletes with real activity to Google's
+      // index (SSG athlete sitemap). Below this the profile is near-empty and is
+      // thin content that shouldn't be crawled. (auditoría 2026-07, SEO)
       `SELECT id, name, username, avatar_url, current_level, total_reps
        FROM users
-       WHERE is_private = false AND username IS NOT NULL AND total_reps > 0
+       WHERE is_private = false AND username IS NOT NULL AND total_reps >= 50
        ORDER BY total_reps DESC
        LIMIT $1`,
       [limit]


### PR DESCRIPTION
## Qué

Task de `docs/auditoria-2026-07-tasks.md` (P2 — SEO fixes): **"Sitemap de atletas: umbral ≥50 reps"** ✅DECIDIDO (2026-07-25: opción A).

`backend/profile.js` — el filtro de `GET /top-public` pasa de `total_reps > 0` a **`total_reps >= 50`**. Perfiles casi vacíos (<50 reps) son thin content que no aporta a Google.

## Blast radius

`/top-public` lo consumen **solo** dos rutas SEO/SSG (verificado por grep):
- `frontend/vite.config.js:58` — prerender SSG de páginas de atleta.
- `frontend/scripts/generate-sitemap.js:149` — sitemap de atletas.

Ninguna UI de runtime depende del endpoint, así que subir el umbral solo reduce qué perfiles se exponen al índice. El build ya degrada con gracia si no hay atletas (hoy devuelve `[]` sin API).

## Verificación

Nivel: **integración local (query) + sintaxis + análisis de consumidores**.

- `node --check backend/profile.js` OK.
- Contra Postgres efímero, con filas límite (10, 49, 50, 500 reps + un username NULL + un privado con 999): la query devuelve **solo** los de 50 y 500 (49 excluido, 50 incluido, NULL/privado excluidos). Umbral correcto e inclusivo en 50.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_