### PR TITLE
docs(db): documentar el rejectUnauthorized:false del pool (decisión B)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -10,8 +10,16 @@ types.setTypeParser(1082, (val) => val);
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  // SSL: for non-local hosts we connect over TLS but with `rejectUnauthorized:
+  // false`, i.e. the transport IS encrypted but the server certificate's CA is
+  // NOT validated (accepts self-signed / unknown-CA certs). This is a deliberate,
+  // low-risk trade-off for the managed Postgres (Supabase) which already enforces
+  // TLS: traffic is not in the clear, we just don't pin/verify the CA chain, so
+  // the residual exposure is a MITM that can present a valid-looking cert — low
+  // for a single trusted managed provider. Local dev (localhost/127.0.0.1) uses
+  // plain TCP, no SSL. (auditoría 2026-07, deuda técnica: decisión B — dejar así.)
   ssl: process.env.DATABASE_URL && !process.env.DATABASE_URL.includes('localhost') && !process.env.DATABASE_URL.includes('127.0.0.1')
-    ? { rejectUnauthorized: false } 
+    ? { rejectUnauthorized: false }
     : false
 });
 


### PR DESCRIPTION
## Qué

Task de `docs/auditoria-2026-07-tasks.md` (P3 — Deuda técnica): **"SSL de db.js: documentar y cerrar"** ✅DECIDIDO (2026-07-25: opción B).

Añade un comentario en `backend/db.js` explicando por qué el Pool usa `ssl: { rejectUnauthorized: false }`: la conexión al Postgres gestionado (Supabase) **ya va cifrada por TLS**; lo único que no se hace es validar el CA del certificado (se aceptan self-signed / unknown-CA). Riesgo residual bajo (MITM con cert válido-aparente) para un único proveedor gestionado de confianza. Local (`localhost`/`127.0.0.1`) va sin SSL.

**Sin cambio de comportamiento** — solo documentación.

## Nota (fuera de esta PR)

El caveat del task "fijar `HEVY_ENCRYPTION_KEY` en Coolify (hoy cae a `JWT_SECRET`/default de dev)" es una **acción de infra (👤)**: poner la variable de entorno en Coolify. No hay cambio de código asociado (el fallback ya existe), así que queda para Roman.

## Verificación

- `node --check backend/db.js` OK. Cambio puramente de comentario.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_