### PR TITLE
feat(campaign): aplicar la maldición de la Senda Oscura al daño (Parte dark de "Sendas de campaña")

### DIFF
--- a/backend/utils/campaignEngine.js
+++ b/backend/utils/campaignEngine.js
@@ -353,7 +353,7 @@ export async function applyCampaignDamage(client, { user, effectiveCount, exerci
   const engRes = await client.query(
     `SELECT unp.id AS progress_id, unp.node_id, unp.enemy_current_hp, unp.enemy_total_hp, unp.kills,
             n.slug AS node_slug, n.type AS node_type, n.pack, n.rewards AS node_rewards, z.slug AS zone_slug, cr.id AS run_id,
-            cr.campaign_id, cr.prestige_level, c.config AS campaign_config,
+            cr.campaign_id, cr.prestige_level, cr.path, c.config AS campaign_config,
             e.id AS enemy_id, e.slug AS enemy_slug, e.family AS enemy_family, e.tier AS enemy_tier,
             e.base_hp, e.weakness_stat, e.resist_stat, e.scaling AS enemy_scaling, e.loot AS enemy_loot
      FROM campaign_runs cr
@@ -384,6 +384,18 @@ export async function applyCampaignDamage(client, { user, effectiveCount, exerci
     const rLvl = Number(user[`${row.resist_stat}_lvl`]) || 1;
     if (rLvl > 1) damage = Math.round(damage / (1 + Math.min(0.5, rLvl * 0.01)));
   }
+
+  // Dark-path curse: the Senda Oscura trades raw power (−25% campaign damage by
+  // default) for higher reward variance. The multiplier lives in the campaign
+  // config (`config.path.dark.curse_damage_multiplier`) so balance stays data-
+  // driven; only applied on the dark path and when the value is a sane fraction.
+  if (row.path === 'dark') {
+    const curse = Number(row.campaign_config?.path?.dark?.curse_damage_multiplier);
+    if (Number.isFinite(curse) && curse > 0 && curse !== 1) {
+      damage = Math.round(damage * curse);
+    }
+  }
+
   damage = Math.max(0, damage);
 
   const packCount = (row.pack && row.pack.count) || 1;


### PR DESCRIPTION
## Qué

Task de `docs/auditoria-2026-07-tasks.md` (P3 — Deuda técnica): **"Sendas de campaña: implementar efectos"** ✅DECIDIDO (2026-07-25: opción A). Esta PR implementa **solo la parte `dark`** (la `light` se aparca — ver abajo).

El efecto `dark.curse_damage_multiplier` estaba **muerto** (definido en el config, nunca aplicado). Ahora `applyCampaignDamage` (`campaignEngine.js`):
- Añade `cr.path` al SELECT para conocer la senda del run.
- En la **Senda Oscura**, multiplica el daño de combate de campaña por `config.path.dark.curse_damage_multiplier` (**0.75** por defecto → −25%). Es el trade-off del dark: menos poder a cambio de mayor varianza de recompensa.

**Data-driven**: el número se lee del JSON del config (`main-campaign.json`), NO se hardcodea — así respeta "usar esos [valores] o ajustar" sin inventar balance. Guardas: solo aplica en `dark` y si el valor es un número finito, >0 y ≠1.

## Parte `light` (blessing_hours): APARCADA ⏸️

El config define `light.blessing_hours: 24`, que es **solo la duración** — **no dice QUÉ hace la bendición** (ni el stat ni la magnitud del buff). Implementarla exigiría **inventar un multiplicador**, justo lo que el task prohíbe ("no implementar a ciegas los multiplicadores sin su OK"). He dejado un `⏸️` en el fichero de tasks pidiendo a Roman que defina el efecto de la bendición.

## Verificación

Nivel: **sintaxis + revisión lógica + smoke test de la aritmética** (un test de integración completo exigiría sembrar el grafo de campaña entero — zonas, nodos, enemigos, progreso engaged — desproporcionado para un multiplicador condicional).

- `node --check backend/utils/campaignEngine.js` OK.
- Smoke test de la lógica: dark 1000 → 750 (×0.75), light 1000 → 1000 (sin efecto), dark 999 → 749. Correcto.
- El daño de campaña es FINAL (regla R4, no se revierte al editar reps), así que la maldición aplica hacia delante sin tocar HP ya snapshotado.

⚠️ Cambio de balance de combate — PR revisable.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_