### PR TITLE
fix(streak): matar el deadlock de freeze + quitar el DDL del hot path

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -295,6 +295,8 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS last_daily_spin_at TIMESTAMP WITH TIM
 ALTER TABLE users ADD COLUMN IF NOT EXISTS has_seen_avatar_overhaul BOOLEAN DEFAULT FALSE;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS last_streak_reward_date DATE;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS push_disabled BOOLEAN DEFAULT FALSE;
+-- Streak weekly-jackpot bookkeeping (antes se creaba en runtime dentro de getStreakStatus).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_jackpot_week TEXT;
 -- "Reto vs tu semana pasada": Monday-anchored week key of the last claimed weekly challenge.
 ALTER TABLE users ADD COLUMN IF NOT EXISTS last_weekly_reto_week TEXT;
 ALTER TABLE user_active_plans ADD COLUMN IF NOT EXISTS last_completed_date DATE;

--- a/backend/utils/streak.js
+++ b/backend/utils/streak.js
@@ -1,4 +1,4 @@
-import pool, { query as defaultQuery } from '../db.js';
+import { query as defaultQuery, withTransaction } from '../db.js';
 import { getLocalDateString } from './date.js';
 
 export const STREAK_FREEZE_COST = 250;
@@ -25,6 +25,25 @@ export const ensureStreakFreezeTable = async (q = defaultQuery) => {
   // Distinguishes the free weekly rest day from the paid 250-coin freeze.
   await q('ALTER TABLE streak_freezes ADD COLUMN IF NOT EXISTS is_rest_day BOOLEAN DEFAULT FALSE');
 };
+
+// Full streak schema bootstrap: the streak_freezes table + the users columns
+// getStreakStatus reads. Runs ONCE at module load (import = app startup) on a
+// normal pooled connection — NEVER inside a caller's transaction. This is what
+// lets the hot paths below stop running DDL per request, and avoids the
+// deadlock that DDL-inside-a-FOR-UPDATE-txn caused (an `ALTER TABLE users …
+// IF NOT EXISTS` takes ACCESS EXCLUSIVE even as a no-op; run on a separate
+// connection while a txn held a FOR UPDATE row lock on users, it blocked
+// forever and PG's deadlock detector never saw it — the txn sat idle-in-
+// transaction). Idempotent; schema.sql covers fresh DBs.
+export const ensureStreakSchema = async (q = defaultQuery) => {
+  await ensureStreakFreezeTable(q);
+  await q('ALTER TABLE users ADD COLUMN IF NOT EXISTS last_jackpot_week TEXT');
+};
+
+// Fired at import; the hot paths `await` it (instant once resolved).
+const schemaReady = ensureStreakSchema().catch((err) => {
+  console.error('[streak] schema bootstrap failed:', err);
+});
 
 const addDays = (date, amount) => {
   const next = new Date(date);
@@ -64,9 +83,9 @@ const countCurrentStreak = (activeDates) => {
 };
 
 export const getStreakStatus = async (userId, q = defaultQuery) => {
-  await ensureStreakFreezeTable(q);
-  // Ensure jackpot tracking column exists (idempotent)
-  await defaultQuery('ALTER TABLE users ADD COLUMN IF NOT EXISTS last_jackpot_week TEXT').catch(() => {});
+  // Schema is bootstrapped once at import (see schemaReady) — no DDL on the hot
+  // path, so this is safe to call from anywhere, including inside a transaction.
+  await schemaReady;
 
   const today = getLocalDateString();
   const yesterday = getLocalDateString(addDays(new Date(), -1));
@@ -142,53 +161,59 @@ export const getStreakStatus = async (userId, q = defaultQuery) => {
 };
 
 export const freezeStreakForToday = async (userId) => {
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-    const q = (text, params) => client.query(text, params);
-    await ensureStreakFreezeTable(q);
+  await schemaReady;
 
-    const userRes = await client.query('SELECT reppy_coins FROM users WHERE id = $1 FOR UPDATE', [userId]);
-    if (userRes.rowCount === 0) {
-      const error = new Error('User not found');
-      error.status = 404;
-      throw error;
-    }
+  // Eligibility read OUTSIDE any transaction. getStreakStatus no longer runs
+  // DDL, but keeping it off the locked path is what kills the old deadlock
+  // (freeze used to hold FOR UPDATE on users while getStreakStatus ran an
+  // ALTER on a second connection → indefinite block).
+  const status = await getStreakStatus(userId);
+  if (!status.isAtRisk) {
+    const error = new Error('Tu racha no esta en riesgo ahora mismo.');
+    error.status = 400;
+    throw error;
+  }
+  if (status.freezesThisWeek >= STREAK_FREEZE_WEEKLY_LIMIT) {
+    const error = new Error('Ya has usado tu congelacion semanal.');
+    error.status = 400;
+    throw error;
+  }
+  if (status.coins < STREAK_FREEZE_COST) {
+    const error = new Error('No tienes monedas suficientes para congelar la racha.');
+    error.status = 400;
+    throw error;
+  }
 
-    const status = await getStreakStatus(userId, q);
-    if (!status.isAtRisk) {
-      const error = new Error('Tu racha no esta en riesgo ahora mismo.');
+  await withTransaction(async (client) => {
+    // Insert first, guarded by UNIQUE(user_id, freeze_date): if today already
+    // has a freeze/rest row, nothing is inserted and we bail WITHOUT charging.
+    const ins = await client.query(
+      `INSERT INTO streak_freezes (user_id, freeze_date, spent_coins, is_rest_day)
+       VALUES ($1, CURRENT_DATE, $2, FALSE)
+       ON CONFLICT (user_id, freeze_date) DO NOTHING`,
+      [userId, STREAK_FREEZE_COST]
+    );
+    if (ins.rowCount === 0) {
+      const error = new Error('Tu racha ya esta protegida hoy.');
       error.status = 400;
       throw error;
     }
-    if (status.freezesThisWeek >= STREAK_FREEZE_WEEKLY_LIMIT) {
-      const error = new Error('Ya has usado tu congelacion semanal.');
-      error.status = 400;
-      throw error;
-    }
-    if (Number(userRes.rows[0].reppy_coins || 0) < STREAK_FREEZE_COST) {
+    // Atomic coin gate: only charge if the balance still covers it. If not, the
+    // whole transaction (including the insert above) rolls back — no free freeze.
+    const upd = await client.query(
+      `UPDATE users SET reppy_coins = reppy_coins - $1
+       WHERE id = $2 AND COALESCE(reppy_coins, 0) >= $1
+       RETURNING reppy_coins`,
+      [STREAK_FREEZE_COST, userId]
+    );
+    if (upd.rowCount === 0) {
       const error = new Error('No tienes monedas suficientes para congelar la racha.');
       error.status = 400;
       throw error;
     }
+  });
 
-    await client.query(
-      'INSERT INTO streak_freezes (user_id, freeze_date, spent_coins) VALUES ($1, CURRENT_DATE, $2)',
-      [userId, STREAK_FREEZE_COST]
-    );
-    await client.query(
-      'UPDATE users SET reppy_coins = GREATEST(0, COALESCE(reppy_coins, 0) - $1) WHERE id = $2',
-      [STREAK_FREEZE_COST, userId]
-    );
-
-    await client.query('COMMIT');
-    return getStreakStatus(userId);
-  } catch (error) {
-    await client.query('ROLLBACK');
-    throw error;
-  } finally {
-    client.release();
-  }
+  return getStreakStatus(userId);
 };
 
 /**


### PR DESCRIPTION
## Qué

Resuelve **2 hallazgos aprobados** de la auditoría ingeniería/seguridad 2026-07-26 (comparten raíz común, por eso van juntos):

- **[ALTA] Deadlock en `freezeStreakForToday`**: abría una txn con `SELECT … FOR UPDATE users` y dentro llamaba a `getStreakStatus`, que ejecutaba `ALTER TABLE users … ADD COLUMN IF NOT EXISTS` en **otra** conexión. En PG16 ese `ADD COLUMN IF NOT EXISTS` toma `ACCESS EXCLUSIVE` **aunque sea no-op** → choca con el `FOR UPDATE`; como la conexión de la txn queda `idle in transaction`, el detector de deadlock de PG **no lo ve** y cuelga indefinidamente. (Verificado con `pg_stat_activity` durante el run que lo descubrió.)
- **[MEDIA] DDL en el hot path**: `getStreakStatus` corría 2 sentencias DDL en **cada** llamada (`/streak/status`, cada recalc de stats, cada log de reps).

## Fix (raíz común)

- **`ensureStreakSchema()` + `schemaReady`**: el DDL (`streak_freezes` + columnas de `users`) corre **una vez al importar el módulo** (= arranque de la app), en una conexión del pool, **nunca dentro de una txn con lock**. Idempotente.
- **`getStreakStatus`** ahora es solo lectura (`await schemaReady`) → sin DDL por request y seguro de llamar desde cualquier sitio, incluida una txn.
- **`freezeStreakForToday`** reescrito sin deadlock (mismo patrón seguro que el día de descanso de #327): lee el estado **fuera** de la txn y dentro hace un `INSERT` guardado por `UNIQUE(user_id, freeze_date)` + un descuento de monedas **atómico** (`UPDATE … WHERE reppy_coins >= coste`, roll-back completo si no cubre). Race-safe, sin doble cobro, sin cobro-sin-freeze.
- **`schema.sql`**: `last_jackpot_week` añadido (antes solo se creaba en runtime).

`getStreakStatus`/`useRestDayForToday` (día de descanso) ya estaban a salvo; esta PR cierra el freeze de pago, que seguía afectado.

## Verificación

Nivel: **integración local con Postgres efímero** (`initdb` + `schema.sql` + flujo real vía los módulos reales).

- **Deadlock:** antes el freeze **colgaba indefinidamente** (exit 124, confirmado con `pg_stat_activity`); ahora **completa en 9 ms**.
- Cobra 250 una vez, racha preservada (1→2), `freezesThisWeek=1`.
- Saldo insuficiente (<250) → rechazado **sin cobro y sin fila**.
- Doble freeze el mismo día → rechazado sin cobro extra.
- **3 freezes concurrentes → exactamente 1 cobro** (750) y 1 fila.
- `getStreakStatus` funciona contra un esquema cargado solo desde `schema.sql` (sin el ALTER de runtime).
- `node --check` OK; suite pura de economía **5/5**.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_