### PR TITLE
fix(security): rate limit en /auth/signup y /auth/google

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -5,7 +5,7 @@ import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
 import { query } from './db.js';
 import { ensureUsername } from './utils/username.js';
-import { loginLimiter } from './utils/rateLimiters.js';
+import { loginLimiter, signupLimiter, oauthLimiter } from './utils/rateLimiters.js';
 
 const router = express.Router();
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
@@ -37,7 +37,7 @@ const applyReferral = async (newUserId, referralCode) => {
 };
 
 // Google Login
-router.post('/google', async (req, res) => {
+router.post('/google', oauthLimiter, async (req, res) => {
   const { token } = req.body;
 
   if (!process.env.GOOGLE_CLIENT_ID) {
@@ -102,7 +102,7 @@ router.post('/google', async (req, res) => {
 });
 
 // Manual Signup
-router.post('/signup', async (req, res) => {
+router.post('/signup', signupLimiter, async (req, res) => {
   const { name, email, password, referral_code: incomingRef } = req.body;
 
   try {

--- a/backend/utils/rateLimiters.js
+++ b/backend/utils/rateLimiters.js
@@ -15,6 +15,31 @@ export const loginLimiter = rateLimit({
   message: { code: 'ERR_RATE_LIMIT', message: 'Demasiados intentos de inicio de sesión. Inténtalo de nuevo en unos minutos.' },
 });
 
+// Account creation guard on manual signup. Keyed by IP. Counts EVERY attempt
+// (skipSuccessfulRequests would defeat the purpose: a mass-signup spammer's
+// requests all "succeed"). `/signup` runs bcrypt on each call and inserts a new
+// user row → both a CPU-DoS vector and a mass-account-creation vector.
+export const signupLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 min
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { code: 'ERR_RATE_LIMIT', message: 'Demasiados registros desde esta red. Inténtalo de nuevo en unos minutos.' },
+});
+
+// Google OAuth (login + first-time signup). Legit users hit this on every login,
+// so only FAILED verifications count (skipSuccessfulRequests) — that's the abuse
+// signal (invalid-token floods) without locking out real logins behind a shared
+// IP / NAT. Keyed by IP.
+export const oauthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 min
+  max: 30,
+  skipSuccessfulRequests: true,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { code: 'ERR_RATE_LIMIT', message: 'Demasiados intentos. Inténtalo de nuevo en unos minutos.' },
+});
+
 // Spam guard on rep logging. Keyed by authenticated user id (this limiter is
 // mounted AFTER `authenticate`, so req.user is always present), falling back to
 // IP defensively. Reps are once-per-day-per-exercise anyway, so a low ceiling


### PR DESCRIPTION
## Qué

Hallazgo **[MEDIA]** de la auditoría ingeniería/seguridad 2026-07-26 (aprobado por Roman): solo `/auth/login` tenía rate limiting. `/auth/signup` es no-autenticado y hace `bcrypt.hash(password, 10)` en cada request → vector de **DoS por CPU** + creación masiva de cuentas.

## Cambios (`utils/rateLimiters.js` + `auth.js`)

- **`signupLimiter`** en `POST /auth/signup` — IP, **10 / 15 min**, cuenta **todas** las peticiones. (`skipSuccessfulRequests` no serviría: las altas de un spammer todas "aciertan", así que hay que contar también las exitosas para frenar el DoS/mass-creation).
- **`oauthLimiter`** en `POST /auth/google` — IP, **30 / 15 min**, `skipSuccessfulRequests: true`. `/google` es el login principal, así que solo cuentan las verificaciones **fallidas** (floods de tokens inválidos) para no bloquear logins legítimos detrás de un NAT.

Ambos devuelven 429 con `{ code: 'ERR_RATE_LIMIT', message }`, mismo formato que `loginLimiter`. Detrás de Coolify/Traefik el app ya tiene `trust proxy`, así que la IP real (`X-Forwarded-For`) es la clave.

## Fuera de scope (a propósito)

La **enumeración de emails** (`ERR_USER_EXISTS` vs `ERR_GOOGLE_ONLY`) que menciona el hallazgo **no se toca**: esos códigos los usa el frontend para guiar al usuario ("usa Google login"). Uniformarlos sería un cambio de comportamiento con impacto en la UI, aparte de este fix de rate limiting.

## Verificación

- `node --check` OK en `auth.js` y `utils/rateLimiters.js`.
- Cambio de configuración de middleware (sin lógica de request nueva que ejercitar sin simular 10+ peticiones). El limiter reutiliza `express-rate-limit`, ya en uso y probado por los limiters existentes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_