### PR TITLE
fix(security): rate limit suave en endpoints de economía

### DIFF
--- a/backend/roulette.js
+++ b/backend/roulette.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { query, withTransaction } from './db.js';
 import { authenticate, optionalAuthenticate } from './middleware.js';
+import { economyLimiter } from './utils/rateLimiters.js';
 
 // How often the free spin recharges. Used by /status and /spin so they can
 // never disagree on whether the user is still on cooldown.
@@ -168,7 +169,7 @@ router.get('/status', optionalAuthenticate, async (req, res) => {
 });
 
 // Spin the wheel
-router.post('/spin', authenticate, async (req, res) => {
+router.post('/spin', authenticate, economyLimiter, async (req, res) => {
   const userId = req.user.id;
 
   try {
@@ -245,7 +246,7 @@ router.post('/spin', authenticate, async (req, res) => {
 });
 
 // Buy ticket and spin (all-in-one for UI convenience)
-router.post('/buy-and-spin', authenticate, async (req, res) => {
+router.post('/buy-and-spin', authenticate, economyLimiter, async (req, res) => {
   const userId = req.user.id;
 
   try {
@@ -352,7 +353,7 @@ router.get('/daily-status', optionalAuthenticate, async (req, res) => {
   }
 });
 
-router.post('/daily-spin', authenticate, async (req, res) => {
+router.post('/daily-spin', authenticate, economyLimiter, async (req, res) => {
   const userId = req.user.id;
 
   try {

--- a/backend/shop.js
+++ b/backend/shop.js
@@ -5,6 +5,7 @@ import { recalculateUserStats } from './utils/stats.js';
 import { updateMissionProgress } from './utils/missions.js';
 import { rotateDailyShop } from './utils/shop_rotation.js';
 import { getPerkBonuses } from './utils/perks.js';
+import { economyLimiter } from './utils/rateLimiters.js';
 
 
 const router = express.Router();
@@ -252,7 +253,7 @@ router.get('/daily', authenticate, async (req, res) => {
 });
 
 // Refresh daily shop
-router.post('/daily/refresh', authenticate, async (req, res) => {
+router.post('/daily/refresh', authenticate, economyLimiter, async (req, res) => {
   try {
     const userId = req.user.id;
 
@@ -384,7 +385,7 @@ router.post('/mark-seen/:id', authenticate, async (req, res) => {
 });
 
 // Buy item
-router.post('/buy/:id', authenticate, async (req, res) => {
+router.post('/buy/:id', authenticate, economyLimiter, async (req, res) => {
   const itemId = parseInt(req.params.id);
   const userId = req.user.id;
 
@@ -795,7 +796,7 @@ router.post('/activate/:id', authenticate, async (req, res) => {
 });
 
 // Buy chest (coins or gems depending on chest type)
-router.post('/buy-chest/:type', authenticate, async (req, res) => {
+router.post('/buy-chest/:type', authenticate, economyLimiter, async (req, res) => {
   const type = req.params.type; // normal, epic, legendary
   const userId = req.user.id;
 

--- a/backend/utils/rateLimiters.js
+++ b/backend/utils/rateLimiters.js
@@ -27,3 +27,17 @@ export const repsLimiter = rateLimit({
   keyGenerator: (req) => req.user?.id || req.ip,
   message: { code: 'ERR_RATE_LIMIT', message: 'Demasiadas peticiones. Espera un momento.' },
 });
+
+// Soft guard on economy-mutating endpoints (roulette spins, shop buys, daily
+// refresh). These already have economic guards (cooldowns, balance checks with
+// FOR UPDATE), so this is DB-load protection, not correctness: a legit user
+// never spins/buys dozens of times per minute, but a script could hammer them.
+// Keyed by authenticated user id (mounted AFTER `authenticate`), IP fallback.
+export const economyLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 min
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.user?.id || req.ip,
+  message: { code: 'ERR_RATE_LIMIT', message: 'Demasiadas peticiones. Espera un momento.' },
+});


### PR DESCRIPTION
## Qué

Hallazgo **[BAJA-MEDIA]** de la auditoría ingeniería/seguridad 2026-07-26 (aprobado por Roman). Los endpoints mutantes de economía no tenían rate limiting:
- `roulette`: `/spin`, `/buy-and-spin`, `/daily-spin`
- `shop`: `/buy/:id`, `/buy-chest/:type`, `/daily/refresh`

Ya tienen guardas económicas (cooldowns, checks de saldo con `FOR UPDATE`), así que esto es **protección de carga de BD, no de correctitud** — un script podría martillearlos (p. ej. `/daily/refresh` en bucle).

## Cambios

- **`economyLimiter`** (`utils/rateLimiters.js`): por **user id** (mounted después de `authenticate`, con fallback a IP), **30 / min**. Margen de sobra para uso legítimo (nadie gira/compra decenas de veces por minuto) y frena el flood por script.
- Aplicado a los 6 endpoints (después de `authenticate`).

## Verificación

- `node --check` OK en `roulette.js`, `shop.js`, `utils/rateLimiters.js`.
- Los 6 endpoints confirmados con el middleware en su sitio. Reutiliza `express-rate-limit`, ya en uso por los limiters existentes.

Con esto quedan cubiertos los **4 hallazgos** de la auditoría ingeniería/seguridad 2026-07-26 (PRs #333, #334 y esta).

---
_Generated by [Claude Code](https://claude.ai/code/session_013SzfqdSDmLYCGdJNyur3ob)_