### PR TITLE
Combate: ejercicio → daño vs weakness/resist (opción B)

### DIFF
--- a/backend/reps.js
+++ b/backend/reps.js
@@ -8,6 +8,7 @@ import { recalculateUserStats, augmentUserWithLevels } from './utils/stats.js';
 import { syncBossHealth } from './utils/boss.js';
 import { getLocalDateString } from './utils/date.js';
 import { calculateDamage } from './utils/damage.js';
+import { getExerciseCombatStat } from './utils/exerciseCombat.js';
 import { getPerkBonuses } from './utils/perks.js';
 import { getUserWithGear } from './utils/user.js';
 import { emitProgress } from './utils/progressEvents.js';
@@ -82,7 +83,7 @@ router.post('/', authenticate, repsLimiter, async (req, res) => {
     await client.query('BEGIN');
     const rawCount = Math.max(0, Number(count) || 0);
     const exerciseMetaRes = await client.query(
-      'SELECT difficulty_multiplier, coin_multiplier, unit, stat_type FROM exercises WHERE slug = $1',
+      'SELECT difficulty_multiplier, coin_multiplier, unit, stat_type, primary_muscle_group FROM exercises WHERE slug = $1',
       [exercise_type]
     );
     const exerciseMeta = exerciseMetaRes.rows[0] || {};
@@ -90,6 +91,7 @@ router.post('/', authenticate, repsLimiter, async (req, res) => {
     const diffMult = exerciseMeta.difficulty_multiplier != null ? Number(exerciseMeta.difficulty_multiplier) : null;
     const coinMult = exerciseMeta.coin_multiplier != null ? Number(exerciseMeta.coin_multiplier) : null;
     const statTypeOverride = exerciseMeta.stat_type || null;
+    const exerciseStat = getExerciseCombatStat(exerciseMeta);
     const effectiveCount = getEffectiveExerciseCount(rawCount, exerciseUnit);
     const rewardCount = getRewardExerciseCount(rawCount, exerciseUnit);
 
@@ -160,6 +162,7 @@ router.post('/', authenticate, repsLimiter, async (req, res) => {
       exerciseType: exercise_type,
       diffMult,
       addedWeight: added_weight,
+      exerciseStat,
     });
 
     if (killed) {
@@ -178,6 +181,7 @@ router.post('/', authenticate, repsLimiter, async (req, res) => {
       exerciseType: exercise_type,
       diffMult,
       addedWeight: added_weight,
+      exerciseStat,
     });
 
     // Update metadata in reps record

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -537,3 +537,10 @@ ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS campaign_node_id INTEGER REFERE
 -- Estilo de interfaz elegido por el usuario ('operative' | 'classic').
 -- Se sincroniza con localStorage (reppy_ui_style) vía PATCH /users/profile.
 ALTER TABLE users ADD COLUMN IF NOT EXISTS ui_style VARCHAR(20) DEFAULT 'operative';
+
+-- Grupo muscular principal del ejercicio (Hevy `primary_muscle_group`: chest,
+-- quadriceps, abdominals…). Alimenta el multiplicador de combate ejercicio→daño
+-- (auditoría 2026-07, opción B): el grupo mapea a un stat de combate (str/vig/end)
+-- que se compara con weakness_stat/resist_stat del enemigo. NULL para los
+-- ejercicios built-in de Reppy, que resuelven vía `stat_type`.
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS primary_muscle_group VARCHAR(50);

--- a/backend/scripts/backfill_exercise_muscle_groups.js
+++ b/backend/scripts/backfill_exercise_muscle_groups.js
@@ -1,0 +1,41 @@
+import { query } from '../db.js';
+import { getMuscleGroupForHevySlug } from '../utils/hevyMuscleGroups.js';
+
+// One-shot backfill of `exercises.primary_muscle_group` for existing Hevy-imported
+// exercises (slug `hevy_<templateId>`), resolved from the bundled template
+// snapshot (backend/data/hevy_exercise_templates.json) — no Hevy API call needed.
+//
+// This feeds the combat exercise-match multiplier (auditoría 2026-07, opción B):
+// a muscle group maps to a combat stat (str/vig/end) compared against the enemy's
+// weakness_stat/resist_stat. Built-in Reppy exercises are left NULL on purpose —
+// they resolve via `stat_type`. Idempotent: only fills rows that are still NULL.
+//
+// Usage: node backend/scripts/backfill_exercise_muscle_groups.js
+async function backfill() {
+  const rows = await query(
+    `SELECT slug FROM exercises
+      WHERE slug LIKE 'hevy\\_%' AND primary_muscle_group IS NULL`
+  );
+
+  console.log(`Found ${rows.rowCount} Hevy exercise(s) without a muscle group.`);
+  let fixed = 0;
+  let unknown = 0;
+
+  for (const { slug } of rows.rows) {
+    const mg = getMuscleGroupForHevySlug(slug);
+    if (!mg) {
+      unknown++;
+      continue; // custom template not in the snapshot → stays NULL (stat_type path)
+    }
+    await query('UPDATE exercises SET primary_muscle_group = $2 WHERE slug = $1', [slug, mg]);
+    fixed++;
+  }
+
+  console.log(`Done. Tagged ${fixed}/${rows.rowCount} exercise(s); ${unknown} unknown (left NULL).`);
+  process.exit(0);
+}
+
+backfill().catch((err) => {
+  console.error('backfill_exercise_muscle_groups failed:', err);
+  process.exit(1);
+});

--- a/backend/tests/combat-exercise-match.test.mjs
+++ b/backend/tests/combat-exercise-match.test.mjs
@@ -1,0 +1,91 @@
+// Pure-function tests for the combat exercise-match multiplier (auditoría 2026-07,
+// "Combate: ejercicio → daño vs weakness/resist", opción B). No DB, no env.
+//
+// Covers: (1) exercise → combat-stat resolution (muscle group vs stat_type), and
+// (2) that calculateDamage applies ×1.4 on weakness match, ×0.7 on resist match,
+// ×1.0 otherwise, and stays neutral when the exercise stat is unknown.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getExerciseCombatStat } from '../utils/exerciseCombat.js';
+import { calculateDamage } from '../utils/damage.js';
+
+test('getExerciseCombatStat — Reppy exercises resolve via stat_type', () => {
+  assert.equal(getExerciseCombatStat({ stat_type: 'str_xp' }), 'str');
+  assert.equal(getExerciseCombatStat({ stat_type: 'pwr_xp' }), 'str');
+  assert.equal(getExerciseCombatStat({ stat_type: 'end_xp' }), 'end');
+  assert.equal(getExerciseCombatStat({ stat_type: 'vig_xp' }), 'vig');
+  // Stats with no muscle mapping (covered by the per-level bonus) → null.
+  assert.equal(getExerciseCombatStat({ stat_type: 'int_xp' }), null);
+  assert.equal(getExerciseCombatStat({ stat_type: 'fth_xp' }), null);
+  assert.equal(getExerciseCombatStat({}), null);
+  assert.equal(getExerciseCombatStat(null), null);
+});
+
+test('getExerciseCombatStat — Hevy imports resolve via muscle group', () => {
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'chest' }), 'str');
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'lats' }), 'str');
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'quadriceps' }), 'vig');
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'glutes' }), 'vig');
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'abdominals' }), 'end');
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'cardio' }), 'end');
+  // Muscle group is case-insensitive and wins over stat_type when both present.
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'QUADRICEPS', stat_type: 'str_xp' }), 'vig');
+  // Unknown muscle group → fall back to stat_type.
+  assert.equal(getExerciseCombatStat({ primary_muscle_group: 'tail', stat_type: 'str_xp' }), 'str');
+});
+
+// A modest user so damage stays finite and comparable across runs. deterministic
+// = true removes crit randomness so the only variable is the exercise multiplier.
+const USER = {
+  current_level: 10, str_lvl: 20, dex_lvl: 5, end_lvl: 15,
+  vig_lvl: 10, int_lvl: 1, fth_lvl: 8, cha_lvl: 1,
+  base_str_lvl: 20, base_end_lvl: 15, base_fth_lvl: 8,
+};
+
+function dmg(boss, exerciseStat) {
+  // reps=10, type=pullups, deterministic (no crit), no override, no weight.
+  return calculateDamage(USER, 10, 'pullups', boss, false, true, null, 0, exerciseStat).totalDamage;
+}
+
+test('calculateDamage — exercise matching weakness_stat amplifies ×1.4', () => {
+  const boss = { weakness_stat: 'str', resist_stat: 'vig' };
+  const neutral = dmg(boss, null);       // no exercise stat → ×1.0
+  const matched = dmg(boss, 'str');      // str exercise vs str weakness → ×1.4
+  const ratio = matched / neutral;
+  assert.ok(Math.abs(ratio - 1.4) < 0.001, `expected ×1.4, got ×${ratio.toFixed(3)}`);
+});
+
+test('calculateDamage — exercise matching resist_stat dampens ×0.7', () => {
+  const boss = { weakness_stat: 'str', resist_stat: 'vig' };
+  const neutral = dmg(boss, null);
+  const resisted = dmg(boss, 'vig');     // vig exercise vs vig resist → ×0.7
+  const ratio = resisted / neutral;
+  assert.ok(Math.abs(ratio - 0.7) < 0.001, `expected ×0.7, got ×${ratio.toFixed(3)}`);
+});
+
+test('calculateDamage — non-matching exercise stat is neutral', () => {
+  const boss = { weakness_stat: 'str', resist_stat: 'vig' };
+  const neutral = dmg(boss, null);
+  const other = dmg(boss, 'end');        // end matches neither → ×1.0
+  assert.equal(other, neutral);
+});
+
+test('calculateDamage — no boss / no weakness metadata → no exercise multiplier', () => {
+  // No boss at all.
+  const noBoss = calculateDamage(USER, 10, 'pullups', null, false, true, null, 0, 'str').totalDamage;
+  const noBossNeutral = calculateDamage(USER, 10, 'pullups', null, false, true, null, 0, null).totalDamage;
+  assert.equal(noBoss, noBossNeutral);
+
+  // Boss without weakness_stat/resist_stat (e.g. community boss SELECT) → neutral.
+  const bareBoss = { current_hp: 1000, total_hp: 1000 };
+  const withStat = calculateDamage(USER, 10, 'pullups', bareBoss, false, true, null, 0, 'str').totalDamage;
+  const withoutStat = calculateDamage(USER, 10, 'pullups', bareBoss, false, true, null, 0, null).totalDamage;
+  assert.equal(withStat, withoutStat);
+});
+
+test('calculateDamage — exerciseMatchMult is reported in the breakdown', () => {
+  const boss = { weakness_stat: 'str', resist_stat: 'vig' };
+  assert.equal(calculateDamage(USER, 10, 'pullups', boss, false, true, null, 0, 'str').exerciseMatchMult, 1.4);
+  assert.equal(calculateDamage(USER, 10, 'pullups', boss, false, true, null, 0, 'vig').exerciseMatchMult, 0.7);
+  assert.equal(calculateDamage(USER, 10, 'pullups', boss, false, true, null, 0, 'end').exerciseMatchMult, 1.0);
+});

--- a/backend/training.js
+++ b/backend/training.js
@@ -5,6 +5,7 @@ import { getExerciseRewards } from './utils/rewards.js';
 import { recalculateUserStats, augmentUserWithLevels } from './utils/stats.js';
 import { getLocalDateString } from './utils/date.js';
 import { calculateDamage } from './utils/damage.js';
+import { getExerciseCombatStat } from './utils/exerciseCombat.js';
 import { emitProgress } from './utils/progressEvents.js';
 import { broadcastDamage } from './socketManager.js';
 import { applyBossDamage } from './utils/combat.js';
@@ -169,14 +170,16 @@ async function getActivePlanBundle(userId) {
 async function applyGuidedRepLog(client, userId, exerciseType, count) {
   if (!count || count <= 0) return { damage: 0, coins: 0 };
 
-  const exRes = await client.query('SELECT difficulty_multiplier, coin_multiplier, unit FROM exercises WHERE slug = $1', [exerciseType]);
+  const exRes = await client.query('SELECT difficulty_multiplier, coin_multiplier, unit, stat_type, primary_muscle_group FROM exercises WHERE slug = $1', [exerciseType]);
   let diffMult = null;
   let coinMult = null;
   let unit = 'reps';
+  let exerciseStat = null;
   if (exRes.rows.length > 0) {
     diffMult = Number(exRes.rows[0].difficulty_multiplier);
     coinMult = Number(exRes.rows[0].coin_multiplier);
     unit = exRes.rows[0].unit || 'reps';
+    exerciseStat = getExerciseCombatStat(exRes.rows[0]);
   }
   const effectiveCount = getEffectiveExerciseCount(count, unit);
   const rewardCount = getRewardExerciseCount(count, unit);
@@ -231,6 +234,7 @@ async function applyGuidedRepLog(client, userId, exerciseType, count) {
     exerciseType,
     diffMult,
     addedWeight: 0,
+    exerciseStat,
   });
 
   // Campaign routing (individual progression). See utils/campaignEngine.js.
@@ -240,6 +244,7 @@ async function applyGuidedRepLog(client, userId, exerciseType, count) {
     exerciseType,
     diffMult,
     addedWeight: 0,
+    exerciseStat,
   });
 
   await client.query(

--- a/backend/utils/campaignEngine.js
+++ b/backend/utils/campaignEngine.js
@@ -346,7 +346,7 @@ export async function prestige(client, userId) {
  *
  * @returns {Promise<null | {nodeId:number, damage:number, killed:boolean, cleared:boolean, loot:object|null}>}
  */
-export async function applyCampaignDamage(client, { user, effectiveCount, exerciseType, diffMult = null, addedWeight = 0 }) {
+export async function applyCampaignDamage(client, { user, effectiveCount, exerciseType, diffMult = null, addedWeight = 0, exerciseStat = null }) {
   const userId = user.id;
 
   // Find the engaged node + its enemy for the user's active run.
@@ -370,12 +370,15 @@ export async function applyCampaignDamage(client, { user, effectiveCount, exerci
   const row = engRes.rows[0];
 
   // Shape the enemy like a boss for calculateDamage (weakness + execution use it).
+  // resist_stat is included so the exercise-match multiplier (opción B) can read
+  // it; the separate per-level resist below is unchanged.
   const enemyAsBoss = {
     weakness_stat: row.weakness_stat,
+    resist_stat: row.resist_stat,
     current_hp: row.enemy_current_hp,
     total_hp: row.enemy_total_hp,
   };
-  const dmg = calculateDamage(user, effectiveCount, exerciseType, enemyAsBoss, false, false, diffMult, addedWeight);
+  const dmg = calculateDamage(user, effectiveCount, exerciseType, enemyAsBoss, false, false, diffMult, addedWeight, exerciseStat);
   let damage = dmg.totalDamage;
 
   // resist_stat: dampen damage if the player leans on the resisted stat. Small,

--- a/backend/utils/combat.js
+++ b/backend/utils/combat.js
@@ -26,9 +26,13 @@ import { emitProgress } from './progressEvents.js';
  * @param {string} params.exerciseType    exercise slug
  * @param {number|null} params.diffMult    difficulty multiplier override
  * @param {number} params.addedWeight     added weight in kg (0 for guided logs)
+ * @param {string|null} params.exerciseStat combat stat of the logged exercise
+ *        (str/vig/end) for the exercise-match multiplier; inert here because the
+ *        community boss SELECT below doesn't carry weakness_stat/resist_stat, but
+ *        threaded for a single consistent damage contract.
  * @returns {Promise<{bossId:number|null, actualDamageDealt:number, killed:boolean, boss:object|null}>}
  */
-export async function applyBossDamage(client, { user, effectiveCount, exerciseType, diffMult = null, addedWeight = 0 }) {
+export async function applyBossDamage(client, { user, effectiveCount, exerciseType, diffMult = null, addedWeight = 0, exerciseStat = null }) {
   const userId = user.id;
 
   const bossRes = await client.query(
@@ -42,7 +46,7 @@ export async function applyBossDamage(client, { user, effectiveCount, exerciseTy
   }
 
   const boss = bossRes.rows[0];
-  const bossDmgResult = calculateDamage(user, effectiveCount, exerciseType, boss, false, false, diffMult, addedWeight);
+  const bossDmgResult = calculateDamage(user, effectiveCount, exerciseType, boss, false, false, diffMult, addedWeight, exerciseStat);
   const actualDamageDealt = bossDmgResult.totalDamage;
 
   // Atomic health deduction — flips to 'defeated' the instant HP hits 0.

--- a/backend/utils/damage.js
+++ b/backend/utils/damage.js
@@ -19,9 +19,12 @@ import { getPerkBonuses } from './perks.js';
  * @param {number} reps Number of repetitions
  * @param {string} type Exercise type (pullups, pushups, etc.)
  * @param {Object} boss Optional boss object to check for weaknesses
- * @returns {Object} { totalDamage, isCrit, magicBonus, baseDamage, weaknessBonus }
+ * @param {string|null} exerciseStat Optional combat stat of the logged exercise
+ *        ('str'|'vig'|'end'); when it matches the boss weakness_stat/resist_stat
+ *        it applies a ×1.4/×0.7 multiplier (auditoría 2026-07, opción B).
+ * @returns {Object} { totalDamage, isCrit, magicBonus, baseDamage, weaknessBonus, exerciseMatchMult }
  */
-export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false, deterministic = false, exerciseMultiplierOverride = null, addedWeightKg = 0) => {
+export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false, deterministic = false, exerciseMultiplierOverride = null, addedWeightKg = 0, exerciseStat = null) => {
   // 1. Determine Exercise Multiplier
   const weight = Math.max(0, Number(addedWeightKg) || 0);
   // Weight bonus: +1 multiplier per 20 kg, capped at +5x (100 kg)
@@ -142,6 +145,22 @@ export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false
     }
   }
 
+  // 5b. Exercise-match multiplier (auditoría 2026-07, opción B). The muscle group
+  // of the *logged exercise* maps to a combat stat (str/vig/end); hitting the
+  // enemy's weakness amplifies, hitting its resist dampens. This is layered ON TOP
+  // of the per-level weakness bonus above — training the right lift, not just
+  // having the right stat leveled, now pays off. Only enemies whose object carries
+  // weakness_stat/resist_stat (campaign enemies) are affected; a null exerciseStat
+  // (unmapped/legacy exercise) stays neutral.
+  let exerciseMatchMult = 1.0;
+  if (boss && exerciseStat) {
+    const es = String(exerciseStat).toLowerCase();
+    const weak = boss.weakness_stat ? String(boss.weakness_stat).toLowerCase() : null;
+    const resist = boss.resist_stat ? String(boss.resist_stat).toLowerCase() : null;
+    if (weak && es === weak) exerciseMatchMult = 1.4;
+    else if (resist && es === resist) exerciseMatchMult = 0.7;
+  }
+
   // execution perk: bonus damage to a boss that's below 25% HP (the finishing blow).
   let executionMult = 1.0;
   if (boss && perks.executionPct > 0 && Number(boss.total_hp) > 0) {
@@ -150,14 +169,14 @@ export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false
   }
 
   // --- FINAL CALCULATIONS (sum across reps via critWeightedReps) ---
-  const totalBase = perRepBaseNoCrit * critWeightedReps * weaknessBonus;
-  const totalWithGear = perRepGearNoCrit * critWeightedReps * weaknessBonus;
+  const totalBase = perRepBaseNoCrit * critWeightedReps * weaknessBonus * exerciseMatchMult;
+  const totalWithGear = perRepGearNoCrit * critWeightedReps * weaknessBonus * exerciseMatchMult;
   const finalDamage = totalWithGear * activeMultiplier * executionMult;
   const gearBonus = Math.max(0, totalWithGear - totalBase);
   const buffBonus = Math.max(0, finalDamage - totalWithGear);
 
   // Theoretical bounds for the whole set: no rep crits ↔ every rep crits.
-  const setNoCrit = perRepGearNoCrit * repsValue * weaknessBonus;
+  const setNoCrit = perRepGearNoCrit * repsValue * weaknessBonus * exerciseMatchMult;
   const setAllCrit = setNoCrit * critMult;
 
   return {
@@ -170,6 +189,7 @@ export const calculateDamage = (user, reps, type, boss = null, skipBuffs = false
     buffBonus: Math.round(buffBonus),
     critMultiplier: parseFloat(critMult.toFixed(2)),
     weaknessBonus: parseFloat(weaknessBonus.toFixed(2)),
+    exerciseMatchMult: parseFloat(exerciseMatchMult.toFixed(2)),
     activeMultiplier: parseFloat(activeMultiplier.toFixed(2)),
     critChance: Math.round(critChance)
   };

--- a/backend/utils/exerciseCombat.js
+++ b/backend/utils/exerciseCombat.js
@@ -1,0 +1,78 @@
+/**
+ * Exercise → combat stat mapping (auditoría 2026-07, "Combate: ejercicio → daño
+ * vs weakness/resist", opción B).
+ *
+ * Beyond the existing per-level weakness bonus, the exercise a player LOGS now
+ * matters: it maps to a "combat stat" (str/vig/end) which is compared against the
+ * enemy's weakness_stat / resist_stat inside calculateDamage:
+ *   - matches weakness_stat → ×1.4
+ *   - matches resist_stat   → ×0.7  (this is what finally makes resist_stat bite)
+ *   - otherwise             → ×1.0
+ *
+ * How the combat stat is resolved (per the audit decision):
+ *   - Reppy built-in exercises already carry a `stat_type` (str_xp/end_xp/pwr_xp…)
+ *     → mapped via STAT_TYPE_TO_COMBAT_STAT.
+ *   - Hevy imports carry a `primary_muscle_group` (chest, quadriceps, …) captured
+ *     at ingest → mapped via MUSCLE_GROUP_TO_COMBAT_STAT (finer: distinguishes
+ *     legs → VIG, which stat_type alone can't).
+ *
+ * DEX/INT/FTH/CHA don't map to a muscle group, so an exercise never yields one of
+ * those combat stats — bosses weak to them are covered by the per-level weakness
+ * bonus, and the exercise multiplier simply lands on the neutral ×1.0 branch.
+ */
+
+// Hevy `primary_muscle_group` → combat stat (from the audit's decided table).
+export const MUSCLE_GROUP_TO_COMBAT_STAT = {
+  // STR — upper body push/pull.
+  chest: 'str',
+  lats: 'str',
+  upper_back: 'str',
+  lower_back: 'str',
+  triceps: 'str',
+  biceps: 'str',
+  forearms: 'str',
+  traps: 'str',
+  shoulders: 'str',
+  // VIG — lower body.
+  quadriceps: 'vig',
+  hamstrings: 'vig',
+  glutes: 'vig',
+  calves: 'vig',
+  abductors: 'vig',
+  adductors: 'vig',
+  // END — core / conditioning / misc.
+  abdominals: 'end',
+  cardio: 'end',
+  full_body: 'end',
+  neck: 'end',
+  other: 'end',
+};
+
+// Reppy `stat_type` (the XP bag an exercise feeds) → combat stat.
+export const STAT_TYPE_TO_COMBAT_STAT = {
+  str_xp: 'str',
+  pwr_xp: 'str', // weighted pull-ups / muscle-ups: upper-body pull → STR
+  end_xp: 'end',
+  vig_xp: 'vig',
+  // dex_xp / int_xp / fth_xp / cha_xp → no muscle mapping (see header).
+};
+
+/**
+ * Resolve the combat stat of a logged exercise.
+ *
+ * @param {object|null} exercise row-like `{ stat_type, primary_muscle_group }`
+ * @returns {'str'|'vig'|'end'|null} null when the exercise has no combat stat
+ *          (leaves the exercise multiplier neutral).
+ */
+export function getExerciseCombatStat(exercise) {
+  if (!exercise) return null;
+  // Prefer the muscle group (Hevy imports) — it's the finer signal.
+  const mg = exercise.primary_muscle_group
+    ? String(exercise.primary_muscle_group).toLowerCase()
+    : null;
+  if (mg && MUSCLE_GROUP_TO_COMBAT_STAT[mg]) return MUSCLE_GROUP_TO_COMBAT_STAT[mg];
+  // Fall back to the exercise's stat_type (Reppy built-ins).
+  const st = exercise.stat_type ? String(exercise.stat_type).toLowerCase() : null;
+  if (st && STAT_TYPE_TO_COMBAT_STAT[st]) return STAT_TYPE_TO_COMBAT_STAT[st];
+  return null;
+}

--- a/backend/utils/hevyIngest.js
+++ b/backend/utils/hevyIngest.js
@@ -21,6 +21,8 @@ import { getExerciseRewards } from './rewards.js';
 import { updateMissionProgress } from './missions.js';
 import { getEffectiveExerciseCount, getRewardExerciseCount, isTimedExerciseUnit } from './exerciseUnits.js';
 import { getExerciseTemplate } from './hevyClient.js';
+import { getMuscleGroupForTemplate } from './hevyMuscleGroups.js';
+import { getExerciseCombatStat } from './exerciseCombat.js';
 
 /**
  * Warmup sets must not count toward reps/damage/coins. Hevy marks them with
@@ -73,15 +75,21 @@ async function resolveExerciseType(client, hevyExercise, apiKey = null) {
 
   const title = await resolveExerciseTitle(hevyExercise, templateId, apiKey, slug);
   const statType = isWeighted ? 'str_xp' : 'end_xp';
+  // Muscle group for the combat exercise-match multiplier (opción B). Prefer the
+  // value on the workout payload, fall back to the bundled template snapshot.
+  const muscleGroup = (hevyExercise.primary_muscle_group
+    ? String(hevyExercise.primary_muscle_group).toLowerCase()
+    : null) || getMuscleGroupForTemplate(templateId);
   await client.query(
-    `INSERT INTO exercises (slug, title_key, description_key, unit, difficulty_multiplier, coin_multiplier, is_active, stat_type)
-     VALUES ($1, $2, $3, $4, 1.0, 1.0, TRUE, $5)
+    `INSERT INTO exercises (slug, title_key, description_key, unit, difficulty_multiplier, coin_multiplier, is_active, stat_type, primary_muscle_group)
+     VALUES ($1, $2, $3, $4, 1.0, 1.0, TRUE, $5, $6)
      ON CONFLICT (slug) DO UPDATE
        SET title_key = EXCLUDED.title_key,
            description_key = EXCLUDED.description_key,
-           unit = EXCLUDED.unit
+           unit = EXCLUDED.unit,
+           primary_muscle_group = COALESCE(exercises.primary_muscle_group, EXCLUDED.primary_muscle_group)
        WHERE exercises.title_key LIKE 'hevy\\_%'`,
-    [slug, title, `Importado de Hevy: ${title}`, unit, statType]
+    [slug, title, `Importado de Hevy: ${title}`, unit, statType, muscleGroup]
   );
   await client.query(
     `INSERT INTO hevy_exercise_map (hevy_template_id, reppy_exercise_type, is_weighted)
@@ -148,17 +156,18 @@ export async function ingestHevyWorkout(userId, workout, { apiKey = null } = {})
       const { type } = await resolveExerciseType(client, ex, apiKey);
       // Pull exercise meta to know how to count.
       const metaRes = await client.query(
-        'SELECT unit, difficulty_multiplier, coin_multiplier FROM exercises WHERE slug = $1',
+        'SELECT unit, difficulty_multiplier, coin_multiplier, stat_type, primary_muscle_group FROM exercises WHERE slug = $1',
         [type]
       );
       const meta = metaRes.rows[0] || {};
       const unit = meta.unit || 'reps';
       const diffMult = meta.difficulty_multiplier != null ? Number(meta.difficulty_multiplier) : null;
       const coinMult = meta.coin_multiplier != null ? Number(meta.coin_multiplier) : null;
+      const exerciseStat = getExerciseCombatStat(meta);
 
       let bucket = agg.get(type);
       if (!bucket) {
-        bucket = { reps: 0, volumeKg: 0, wRepSum: 0, wWeightSum: 0, unit, diffMult, coinMult };
+        bucket = { reps: 0, volumeKg: 0, wRepSum: 0, wWeightSum: 0, unit, diffMult, coinMult, exerciseStat };
         agg.set(type, bucket);
       }
       for (const s of workingSets(ex)) {
@@ -229,7 +238,7 @@ export async function ingestHevyWorkout(userId, workout, { apiKey = null } = {})
       // Boss damage (x1).
       let dmg = 0;
       if (boss && !bossKilled) {
-        const dmgResult = calculateDamage(augmentedUser, effectiveCount, type, boss, false, false, b.diffMult);
+        const dmgResult = calculateDamage(augmentedUser, effectiveCount, type, boss, false, false, b.diffMult, 0, b.exerciseStat);
         dmg = dmgResult.totalDamage;
         const upd = await client.query(
           `UPDATE boss_fights

--- a/backend/utils/hevyMuscleGroups.js
+++ b/backend/utils/hevyMuscleGroups.js
@@ -1,0 +1,54 @@
+/**
+ * Lookup of a Hevy exercise template's `primary_muscle_group` from the bundled
+ * snapshot (`backend/data/hevy_exercise_templates.json`, 484 standard templates).
+ *
+ * Used to tag Hevy-imported exercises with a muscle group so the combat
+ * exercise-match multiplier (auditoría 2026-07, opción B) can resolve them via
+ * MUSCLE_GROUP_TO_COMBAT_STAT. Custom user templates (not in the snapshot) return
+ * null and fall back to the exercise's stat_type.
+ *
+ * Reppy stores Hevy exercises as slug `hevy_<templateId lowercased>`, so lookups
+ * are keyed by the lowercased template id.
+ */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let _map = null;
+
+/** Lazily build the id→muscle_group map (once per process). Best-effort. */
+function getMap() {
+  if (_map) return _map;
+  _map = new Map();
+  try {
+    const raw = readFileSync(join(__dirname, '..', 'data', 'hevy_exercise_templates.json'), 'utf8');
+    const data = JSON.parse(raw);
+    for (const t of (data.exercise_templates || [])) {
+      if (t && t.id && t.primary_muscle_group) {
+        _map.set(String(t.id).toLowerCase(), String(t.primary_muscle_group).toLowerCase());
+      }
+    }
+  } catch (err) {
+    console.warn('[Hevy] could not load exercise templates for muscle groups:', err.message);
+  }
+  return _map;
+}
+
+/**
+ * @param {string} templateId Hevy exercise_template_id (any case)
+ * @returns {string|null} primary_muscle_group (lowercased) or null if unknown
+ */
+export function getMuscleGroupForTemplate(templateId) {
+  if (!templateId) return null;
+  return getMap().get(String(templateId).toLowerCase()) || null;
+}
+
+/** Given a Reppy `hevy_<id>` slug, return the muscle group (or null). */
+export function getMuscleGroupForHevySlug(slug) {
+  if (!slug) return null;
+  const m = /^hevy_(.+)$/i.exec(slug);
+  if (!m) return null;
+  return getMuscleGroupForTemplate(m[1]);
+}


### PR DESCRIPTION
## Qué

Task **P2 — "Combate: ejercicio → daño vs weakness/resist"** (✅DECIDIDO+TABLA, opción B) de `docs/auditoria-2026-07-tasks.md`.

Mantiene el bono por nivel de stat **y añade** un multiplicador por el **ejercicio logueado**. El grupo muscular del ejercicio mapea a un stat de combate (`str`/`vig`/`end`) que se compara con el enemigo:

| Caso | Multiplicador |
|---|---|
| stat-del-ejercicio == `weakness_stat` | **×1.4** |
| stat-del-ejercicio == `resist_stat` | **×0.7** (activa `resist_stat`, hasta ahora inerte en este eje) |
| si no | ×1.0 |

### Cómo se resuelve el stat del ejercicio (según la decisión)
- **Ejercicios de Reppy** → vía su `stat_type` (`str_xp`/`pwr_xp`→str, `end_xp`→end, `vig_xp`→vig). `dex/int/fth/cha` no mapean a músculo → quedan neutros (los cubre el bono por nivel).
- **Importados de Hevy** → vía `primary_muscle_group` (columna nueva). Se captura en el ingest y hay un backfill para los ya existentes desde el snapshot `data/hevy_exercise_templates.json`. Mapa de grupos: chest/lats/upper_back/lower_back/triceps/biceps/forearms/traps/shoulders→**STR**; quadriceps/hamstrings/glutes/calves/abductors/adductors→**VIG**; abdominals/cardio/full_body/neck/other→**END**.

## Alcance real del efecto (importante para revisar)
El multiplicador vive en `damage.js` (una sola fuente) pero **solo se activa cuando el objeto del enemigo lleva `weakness_stat`/`resist_stat`** → hoy eso es **únicamente la campaña** (`campaignEngine.js`). El **boss comunitario** y el **ingest de Hevy** hacen un `SELECT` que no trae `weakness_stat`, así que ahí el multiplicador es neutro (×1.0) — **comportamiento actual sin cambios**. El threading está puesto en esos paths igualmente para que sea un contrato único (si algún día se añade weakness al boss comunitario, el mecanismo va incluido).

⚠️ **A tener en cuenta**: en la campaña ya existía un resist **por nivel de stat** (`campaignEngine.js:383-386`, divide hasta ÷1.5). El nuevo resist es **por ejercicio** (×0.7) y es independiente; en el peor caso (ejercicio resistido + stat resistido muy nivelado) se acumulan (~×0.47). Es el caso "ejercicio equivocado", pero lo señalo por si prefieres tocar/quitar el resist por nivel.

## Archivos
- `utils/exerciseCombat.js` (nuevo) — mapas + `getExerciseCombatStat`.
- `utils/damage.js` — nuevo param `exerciseStat` + bloque 5b (×1.4/×0.7) + `exerciseMatchMult` en el breakdown.
- `utils/campaignEngine.js` — `resist_stat` en `enemyAsBoss` + pasa `exerciseStat`.
- `utils/combat.js`, `reps.js`, `training.js`, `utils/hevyIngest.js` — threading del stat.
- `schema.sql` — `ALTER TABLE exercises ADD COLUMN IF NOT EXISTS primary_muscle_group`.
- `utils/hevyMuscleGroups.js` (nuevo) + `scripts/backfill_exercise_muscle_groups.js` (nuevo, one-shot idempotente, sin red).
- `tests/combat-exercise-match.test.mjs` (nuevo).

**Migración a correr en prod** (además del schema): `node backend/scripts/backfill_exercise_muscle_groups.js` para etiquetar los `hevy_*` existentes. No es imprescindible para que funcione (sin él, los Hevy resuelven vía `stat_type`), solo añade la resolución fina de VIG para piernas.

## Verificación — `integración local`
- **PostgreSQL 16 efímero local**: `schema.sql` carga limpio y es idempotente (re-run sin errores); la columna `primary_muscle_group` existe; el script de backfill etiqueta correctamente (`hevy_b4f2ff72`→`abdominals`, custom UUID desconocido→NULL) y es idempotente; el path DB-row→`getExerciseCombatStat` da los stats esperados.
- **Unit tests**: `tests/combat-exercise-match.test.mjs` — 7/7 (resolución de mapas + math del multiplicador: ×1.4 weakness, ×0.7 resist, neutro sin match / sin boss / sin weakness / breakdown). Suite `economy-math` existente sigue verde.
- **`node --check`** en los 9 ficheros JS tocados: OK.
- No se testeó contra prod (prohibido). No se pudo ejercitar el flujo HTTP completo contra un enemigo de campaña (requiere seed pesado de campaña); la math del daño queda fijada por los unit tests y la resolución verificada contra PG real.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153GiDa7zMZCTVXf9B6q1qB)_