### PR TITLE
Sendas de campaña: bendición de la Senda de Luz (+20% daño 24h)

### DIFF
--- a/backend/data/campaigns/main-campaign.json
+++ b/backend/data/campaigns/main-campaign.json
@@ -12,7 +12,7 @@
     "rewards": { "prestige_mult": 1.25 },
     "path": {
       "dark": { "reward_variance": "high", "curse_damage_multiplier": 0.75 },
-      "light": { "reward_variance": "low", "blessing_hours": 24 }
+      "light": { "reward_variance": "low", "blessing_hours": 24, "blessing_damage_mult": 1.20 }
     }
   },
 

--- a/backend/utils/campaignEngine.js
+++ b/backend/utils/campaignEngine.js
@@ -298,7 +298,41 @@ export async function choosePath(client, userId, path, augmentedUser) {
     [run.id, cross.id]
   );
 
-  return { status: 200, body: { message: 'Senda elegida', path } };
+  // Light-path blessing: the temporal mirror of the dark-path curse. Whereas the
+  // dark curse dampens every campaign hit (config.path.dark.curse_damage_multiplier),
+  // choosing light grants a one-off +X% damage buff for N hours via the existing
+  // global damage_multiplier mechanism (same as potions). Values are data-driven
+  // (config.path.light.blessing_damage_mult / blessing_hours). We only apply it
+  // when it wouldn't shrink a stronger buff the player already has active, so the
+  // reward never backfires (NOTE: the mechanism is global, so the +X% also boosts
+  // community-boss damage for the window, not only campaign).
+  let blessing = null;
+  if (path === 'light') {
+    const mult = Number(run.campaign_config?.path?.light?.blessing_damage_mult);
+    const hours = Number(run.campaign_config?.path?.light?.blessing_hours) || 24;
+    if (Number.isFinite(mult) && mult > 1 && Number.isFinite(hours) && hours > 0) {
+      const updBlessing = await client.query(
+        `UPDATE users
+            SET damage_multiplier = $1,
+                damage_multiplier_expiry = NOW() + ($2 || ' hours')::interval
+          WHERE id = $3
+            AND (damage_multiplier_expiry IS NULL
+                 OR damage_multiplier_expiry <= NOW()
+                 OR COALESCE(damage_multiplier, 1.0) <= $1)
+          RETURNING damage_multiplier, damage_multiplier_expiry`,
+        [mult, String(hours), userId]
+      );
+      if (updBlessing.rowCount > 0) {
+        blessing = {
+          damage_multiplier: Number(updBlessing.rows[0].damage_multiplier),
+          expiry: updBlessing.rows[0].damage_multiplier_expiry,
+          hours,
+        };
+      }
+    }
+  }
+
+  return { status: 200, body: { message: 'Senda elegida', path, blessing } };
 }
 
 /**


### PR DESCRIPTION
## Qué

Task **P3 — "Sendas de campaña: falta la bendición (light)"** (✅DECIDIDO+NÚMERO) de `docs/auditoria-2026-07-tasks.md`. Completa el par: la parte `dark` (maldición −25%) ya se mergeó en #332; esto añade la **bendición de la Senda de Luz**.

Al elegir la senda de luz en la encrucijada se concede **+20% de daño durante 24h**, usando el mecanismo global existente `users.damage_multiplier` / `damage_multiplier_expiry` (el mismo de las pociones). Valores **data-driven** en `config.path.light`:
- `blessing_damage_mult: 1.20`
- `blessing_hours: 24` (ya existía)

## Detalles de implementación
- **`data/campaigns/main-campaign.json`** — `light.blessing_damage_mult = 1.20`.
- **`utils/campaignEngine.js` `choosePath()`** — al fijar `path='light'`, aplica el buff **dentro de la misma transacción** (`withTransaction`, atómico con el set del path). Devuelve `blessing` en el body de la respuesta (el frontend puede mostrarlo; no añado UI porque hay congelación 🧊 de features/rediseños).
- **Overwrite "no-harm"**: el `UPDATE` solo pisa el multiplicador si **no hay un buff activo más fuerte** (`WHERE expiry IS NULL OR expiry <= NOW() OR damage_multiplier <= 1.20`). Así la bendición nunca reduce una poción activa mejor. Trade-off: si el jugador tiene una poción >1.20 activa al elegir la senda, se salta la bendición (ya tiene algo mejor). Lo señalo por si prefieres una versión que apile/extienda.

## Nota de diseño (asimetría intencional)
La maldición `dark` es **por-golpe y solo campaña** (permanente durante la run); la bendición `light` es un **buff global de 24h** (también afecta al daño del boss comunitario durante la ventana). No es un espejo mecánico exacto sino **temporal**, tal como decidió la task ("usar el mecanismo existente `damage_multiplier`/`expiry`").

## Migración en prod
El runtime lee `campaigns.config` de la BD, no del JSON. Para que la bendición tenga efecto hay que **re-sembrar la config**: `node backend/scripts/seed_campaign.js` (upsert `ON CONFLICT DO UPDATE SET config = EXCLUDED.config`) — mismo patrón que necesitó el dark curse de #332.

## Verificación — `integración local`
- **PostgreSQL 16 efímero local**: probada la semántica exacta del `UPDATE` de la bendición sobre 4 estados de usuario:
  - sin buff → recibe 1.2× / 24h ✓
  - buff débil activo (1.1×) → mejora a 1.2× / 24h ✓
  - buff fuerte activo (2.0×) → **intacto** (no-harm) ✓
  - buff expirado (3.0×) → reemplazado por 1.2× / 24h ✓

  Interval SQL (`($n || ' hours')::interval`) validado.
- **`node --check`** en `campaignEngine.js`: OK. JSON válido; `config.path.light` correcto.
- No se ejercitó el flujo HTTP completo `POST /choose-path` (requiere una run de campaña avanzada hasta la encrucijada); la lógica de la bendición queda verificada a nivel de query contra PG real, y el resto de `choosePath` no se toca.
- Prohibido testear contra prod: no se hizo.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153GiDa7zMZCTVXf9B6q1qB)_