### PR TITLE
SEO: noindex en la ruta catch-all (soft-404)

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -392,6 +392,18 @@ export function setupRouterGuards(router) {
         let el = document.querySelector(`meta[name="${name}"]`) || document.querySelector(`meta[property="${name}"]`);
         if (el) el.setAttribute('content', content);
       });
+
+      // Soft-404 fix (auditoría 2026-07, SEO): la ruta catch-all (`not-found`)
+      // se sirve con HTTP 200 vía el fallback SPA, así que sin esto Google podría
+      // indexar URLs inventadas. Marcamos la not-found como `noindex` y
+      // restauramos el `index` por defecto en cualquier otra ruta. (El 404 real
+      // por status HTTP sigue necesitando la config de Traefik/Coolify.)
+      const robotsEl = document.querySelector('meta[name="robots"]');
+      if (robotsEl) {
+        robotsEl.setAttribute('content', to.name === 'not-found'
+          ? 'noindex, follow'
+          : 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+      }
     }
 
     const isAuthenticated = authStore.isAuthenticated


### PR DESCRIPTION
## Qué

Parte **code-side** de la task SEO **"Soft-404 global"** de `docs/auditoria-2026-07-tasks.md` (P2 — SEO fixes). La task prescribe: *"Fallback 404 real o `noindex` en el catch-all del router + config Traefik/Coolify"*. Esto implementa el **`noindex` en el catch-all** (la parte de código); el **404 real por status HTTP** sigue necesitando la config de Traefik/Coolify (infra, no toca aquí).

## Problema
Cualquier URL inventada se sirve con **HTTP 200** (fallback SPA → `index.html`), el router matchea la ruta catch-all `not-found`, y el guard le ponía un **canonical auto-referente** con `robots: index, follow` heredado de `index.html`. Resultado: Google puede indexar URLs basura.

## Fix
En el guard `beforeEach` (`frontend/src/router.js`), tras sincronizar los metas, se ajusta `<meta name="robots">`:
- ruta `not-found` → **`noindex, follow`**
- cualquier otra ruta → restaura el `index, follow, max-image-preview:...` por defecto

Cambio contenido, sin tocar el resto del pipeline SEO/SSG.

## Verificación — `solo build+sintaxis` (frontend)
- **`npm run build` (vite-ssg) OK**: build completo, SEO patch corre, 44 posts indexados.
- **Comprobado el output**: las páginas prerenderizadas reales (`dist/es/index.html`, `dist/es/blog/*.html`) mantienen `robots: index, follow` — el `noindex` **no** se filtró a ningún HTML estático (solo vive como string en el bundle JS, aplicado en runtime únicamente en la ruta not-found, que no se prerenderiza).
- La ruta not-found se resuelve en cliente (fallback SPA); Googlebot ejecuta JS y verá el `noindex`.

Nota: el status sigue siendo 200 hasta que se configure el 404 real en Traefik/Coolify — pero el `noindex` ya evita la indexación de URLs inventadas, que es el daño SEO principal.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153GiDa7zMZCTVXf9B6q1qB)_