### PR TITLE
SEO: `/` → 301 al landing por idioma (elimina el 200 duplicado de la raíz)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,12 @@
+# Idioma de destino del 301 de la raíz. Espeja la detección que hacía el
+# router en cliente (stores/i18n.js: navegador en inglés → /en), pero el
+# DEFECTO es `es` — así los crawlers (que no mandan Accept-Language) y el
+# tráfico hispano caen en /es, el idioma principal del proyecto.
+map $http_accept_language $reppy_root_locale {
+    default   es;
+    ~*^en     en;
+}
+
 server {
     listen 80;
     server_name _;
@@ -24,6 +33,19 @@ server {
     # redirect absoluto saldría como http:// y forzaría un doble salto.
     # Con esto el Location es relativo y el 301 resuelve en un solo salto https.
     absolute_redirect off;
+
+    # SEO: la raíz devolvía 200 con el contenido de /es y un canonical a /es
+    # (duplicado blando que Google tiene que resolver por su cuenta). Ahora es
+    # un 301 real. Match exacto: NO afecta a /join, /es/*, /en/* ni al fallback
+    # SPA de `try_files … /index.html` (redirección interna a /index.html, que
+    # matchea `location /`, no `location = /`).
+    # `$is_args$args` es obligatorio: al llevar el destino una variable, nginx
+    # NO reengancha la query string por su cuenta (verificado) y se perderían
+    # las UTM de las campañas que apuntan a la raíz.
+    location = / {
+        add_header Vary "Accept-Language" always;
+        return 301 /$reppy_root_locale$is_args$args;
+    }
 
     # SEO: post antiguo consolidado en la guía pilar de pike push ups.
     # 301 para que Google transfiera las señales a la página que sí rankea.


### PR DESCRIPTION
## Qué

Task **P2 — SEO fixes → «`/` → 301 a `/es`» (hoy 200 con canonical)** de `docs/auditoria-2026-07-tasks.md`.

Resulta que **sí es implementable por código**: `frontend/nginx.conf` está versionado en el repo y es el que sirve el frontend (`frontend/Dockerfile:26` lo copia a `/etc/nginx/conf.d/default.conf`). No hace falta tocar Traefik/Coolify.

## Problema

`/` está pre-renderizada por SSG (`vite.config.js` la incluye en `includedRoutes`) → nginx la servía con **HTTP 200** y el contenido de `/es`, con canonical a `/es`. Es un duplicado blando que Google tiene que resolver por su cuenta.

## Fix

```nginx
map $http_accept_language $reppy_root_locale {
    default   es;
    ~*^en     en;
}

location = / {
    add_header Vary "Accept-Language" always;
    return 301 /$reppy_root_locale$is_args$args;
}
```

**Por qué el `map` y no un `return 301 /es;` seco** (única desviación de la letra de la task, la señalo explícitamente): hoy la raíz **no** manda a `/es` siempre. El router hace una redirección adaptativa (`frontend/src/router.js:33-38`) con el idioma de `stores/i18n.js:16-18`, cuya regla es *`navigator.language === 'es' ? 'es' : 'en'`* → **un navegador en inglés (o en francés) aterriza hoy en `/en`**. Un 301 duro a `/es` mandaría a todos los angloparlantes al landing en español.

El `map` conserva lo que importa (navegador en inglés → `/en`) y deja **`es` como defecto** para todo lo demás, incluidos los crawlers, que no mandan `Accept-Language` → **Googlebot ve exactamente el `/` → 301 → `/es` que pedía la task**. Si prefieres el 301 seco a `/es`, es borrar el `map` y dejar `return 301 /es$is_args$args;`.

**Un bug que atrapó la prueba**: con una variable en el destino, nginx **no** reengancha la query string por su cuenta. La primera versión (`return 301 /$reppy_root_locale;`) se **comía las UTM** de las campañas que apuntan a la raíz (justo el canal de TikTok del plan). De ahí el `$is_args$args`.

## Alcance / lo que NO cambia

- `location = /` es **match exacto**: no toca `/join`, `/es/*`, `/en/*` ni ninguna otra ruta.
- **El fallback SPA sigue intacto**: `try_files … /index.html` es una redirección *interna* a la URI `/index.html`, que matchea `location /`, **no** `location = /`. Verificado con peticiones reales (abajo).
- `manifest.json` mantiene `start_url: "/"` → la PWA instalada hace ahora un salto 301 y sigue resolviendo el idioma por cabecera. Lo dejo así a propósito; cambiarlo a `/es` fijaría el idioma de la app instalada.
- El redirect de `/` del router se queda: sigue haciendo falta para la navegación interna y para el caso en que se sirve el fallback SPA.
- La raíz no está en el sitemap (verificado en `sitemap-pages.xml`), así que no queda ninguna URL sitemapeada apuntando a un 301.

**Nota de review**: el `add_header Vary` dentro del `location` hace que ese 301 concreto no herede los 3 headers de seguridad del nivel `server` (regla de herencia de `add_header` en nginx). En una respuesta 301 sin cuerpo útil es inocuo, pero lo digo para que no te sorprenda.

## Verificación — `integración local` (nginx real, no solo lectura del diff)

No hay build de JS que verificar (el cambio es solo config de nginx), así que instalé **nginx 1.24 en el sandbox** y levanté el `nginx.conf` **real del repo** (solo sustituyendo `listen` y `root`) contra un árbol que imita la salida de `vite-ssg` (`index.html`, `es.html`, `en.html`, `es/blog.html`, `assets/*`):

| Petición | Resultado |
|---|---|
| `GET /` sin `Accept-Language` | **301 → `/es`** ✅ |
| `GET /` con `en-US,en;q=0.9` | **301 → `/en`** ✅ |
| `GET /` con `es-ES,es;q=0.9,en;q=0.8` | 301 → `/es` ✅ |
| `GET /` con `fr-FR` | 301 → `/es` ✅ |
| `GET /?utm_source=tiktok&utm_medium=bio` | 301 → `/es?utm_source=tiktok&utm_medium=bio` ✅ |
| `GET /es`, `/en`, `/es/blog` | 200 (sin cambios) ✅ |
| `GET /join?ref=ABC` | 200, fallback SPA ✅ |
| `GET /es/dashboard` | 200, fallback SPA (el F5 sigue funcionando) ✅ |
| `GET /es/blog/rutina-pike-pushups` | 301 al pilar (redirect previo intacto) ✅ |
| `GET /en/blog/guia-definitiva-dominadas` | 301 al `slugEn` (intacto) ✅ |
| `GET /assets/nope.js` | 404 (intacto) ✅ |
| Siguiendo el 301 (`curl -L`) | `/` → `LANDING-ES`; con `en-GB` → `LANDING-EN` ✅ |

Además `nginx -t` pasa (el `map` en contexto `http` es válido tal y como se incluye el fichero desde `conf.d/`).

Prohibido testear contra prod: no se hizo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq5SbpkScbpmX5Yk5TSti4)_