### PR TITLE
balance(economía): pociones de DEX — Maestría del Cuerpo 18k→40k, Sangre de Dragón 6k→13k

### DIFF
--- a/backend/archive/diversify_consumables.js
+++ b/backend/archive/diversify_consumables.js
@@ -74,7 +74,9 @@ const consumables = [
         description: 'La sangre de la bestia fluye por tus venas, otorgándote una Destreza (DEX) legendaria.',
         type: 'consumable',
         rarity: 'legendary',
-        price: 6000,
+        // Rebalance 2026-07-27: 6.000 → 13.000. Sube con "Maestría del Cuerpo" para no
+        // quedarse como el nuevo outlier de ratio daño/coste un escalón por debajo.
+        price: 13000,
         stats: { duration: 21600, dex_bonus: 50 }
     },
     // Rarity: calistenico (24h = 86400s)
@@ -91,7 +93,9 @@ const consumables = [
         description: 'La culminación del control físico. Tu Destreza (DEX) es inigualable.',
         type: 'consumable',
         rarity: 'calistenico',
-        price: 18000,
+        // Rebalance 2026-07-27: 18.000 → 40.000. Era el outlier de ratio daño/coste del
+        // juego (el crítico escala con DEX). Ver backend/scripts/update_dex_potion_prices.js.
+        price: 40000,
         stats: { duration: 86400, dex_bonus: 100 }
     }
 ];

--- a/backend/scripts/update_dex_potion_prices.js
+++ b/backend/scripts/update_dex_potion_prices.js
@@ -1,0 +1,50 @@
+import { query } from '../db.js';
+
+// One-shot rebalance de precios de las pociones de DEX (auditoría 2026-07, decidido
+// por Roman el 2026-07-27).
+//
+// Motivo: la poción calisténica "Maestría del Cuerpo" (+100 dex, 24h) a 18.000 monedas
+// era un outlier de ratio daño/coste — el crítico escala con DEX (`critMult = 2 + dex*0.1`),
+// así que era, con diferencia, la compra más rentable del juego. Sube a 40.000.
+// "Sangre de Dragón" (legendary, +50 dex, 6h) sube a 13.000 para no convertirse ella
+// en el nuevo outlier un escalón por debajo.
+//
+// Los items VIVEN EN LA TABLA `items` (ya sembrada); el seed `archive/diversify_consumables.js`
+// NO corre en runtime, por eso hace falta este UPDATE además de actualizar el seed.
+//
+// Idempotente: re-ejecutarlo deja los mismos precios.
+//
+// Uso: node backend/scripts/update_dex_potion_prices.js
+const NEW_PRICES = [
+  { name: 'Maestría del Cuerpo', price: 40000 },
+  { name: 'Sangre de Dragón', price: 13000 },
+];
+
+async function updatePrices() {
+  for (const { name, price } of NEW_PRICES) {
+    const res = await query(
+      `UPDATE items SET price = $2
+        WHERE name = $1::text AND type = 'consumable'
+        RETURNING id, name, price`,
+      [name, price]
+    );
+
+    if (res.rowCount === 0) {
+      console.warn(`⚠️  No se encontró el consumible "${name}" — nada que actualizar.`);
+      continue;
+    }
+    for (const row of res.rows) {
+      console.log(`✅ ${row.name} (id ${row.id}) → ${row.price} monedas`);
+    }
+  }
+}
+
+updatePrices()
+  .then(() => {
+    console.log('Precios de pociones DEX actualizados.');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Error actualizando precios:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Implementa la task **"Nerfear pociones DEX de crit: subir precio a 40.000"** (P1 — Rebalance económico), tal y como la resolviste el 2026-07-27:

- **Maestría del Cuerpo** (`calistenico`, +100 dex, 24h): **18.000 → 40.000** monedas.
- **Sangre de Dragón** (`legendary`, +50 dex, 6h): **6.000 → 13.000** monedas — para que no se convierta ella en el nuevo outlier un escalón por debajo.

## Por qué hacen falta dos piezas

Los items reales viven en la tabla `items` (ya sembrada) y el seed `backend/archive/diversify_consumables.js` **no se ejecuta en runtime**, así que editarlo solo no cambia nada en una BD ya poblada. El PR trae las dos:

| Archivo | Qué hace |
|---|---|
| `backend/scripts/update_dex_potion_prices.js` (nuevo) | One-shot idempotente con los dos `UPDATE items SET price = $2 WHERE name = $1 AND type = 'consumable'`. Es lo que hay que ejecutar para que el cambio surta efecto sobre la BD actual. |
| `backend/archive/diversify_consumables.js` | Precios actualizados para futuras siembras, con comentario del porqué. |

Lo puse en `backend/scripts/` (seeds vigentes) en lugar de `backend/tmp/` porque `tmp/` está marcado como cruft a borrar en el backlog de deuda técnica.

### Para aplicarlo
```bash
node backend/scripts/update_dex_potion_prices.js   # con DATABASE_URL apuntando a la BD
```
Avisa con un warning (no falla) si algún item no existe, y re-ejecutarlo deja los mismos precios.

## Verificación: **integración local**

Postgres 16 efímero en el sandbox, `backend/schema.sql` cargado, más el DDL de `items` (que curiosamente no vive en `schema.sql` sino en `profile.js:14` — es el drift que trackea la task de "unificar las 3 fuentes de esquema", no lo toco aquí).

- Sembrados los dos consumibles con los precios viejos + un tercer item señuelo → el script actualiza **solo los dos objetivo** (40.000 / 13.000), el señuelo intacto.
- **Idempotencia**: segunda ejecución → mismos precios, sin error.
- `node --check` en los dos ficheros tocados.
- No se tocó la BD de producción ni ningún entorno desplegado.

Sin cambios de frontend, así que no hay build de Vite que reportar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNEe7PaSrajFNupFZFSqL1)_