### PR TITLE
balance(campaña): HP enemigo cuadrático (1 + 0.06·L + 0.03·L²)

### DIFF
--- a/backend/data/campaigns/main-campaign.json
+++ b/backend/data/campaigns/main-campaign.json
@@ -8,7 +8,7 @@
     "en": "Cross the forest, the crypt and the domain of your path to forge a legend."
   },
   "config": {
-    "hp": { "base_per_level": 0.06, "tier_mult": [1, 1.8, 3, 6, 12], "prestige_mult": 1.5 },
+    "hp": { "base_per_level": 0.06, "quad_per_level": 0.03, "tier_mult": [1, 1.8, 3, 6, 12], "prestige_mult": 1.5 },
     "rewards": { "prestige_mult": 1.25 },
     "path": {
       "dark": { "reward_variance": "high", "curse_damage_multiplier": 0.75 },

--- a/backend/scripts/analyze_economy_curves.js
+++ b/backend/scripts/analyze_economy_curves.js
@@ -44,6 +44,12 @@ function expectedCritMultiplier(L) {
   return (1 - p) + p * mult;
 }
 
+// Mirrors config.hp of backend/data/campaigns/main-campaign.json, so the table shows
+// the curve that actually ships (the code defaults differ only in base_per_level).
+const CAMPAIGN_CONFIG = {
+  hp: { base_per_level: 0.06, quad_per_level: 0.03, tier_mult: [1, 1.8, 3, 6, 12], prestige_mult: 1.5 },
+};
+
 console.log('=== 1) PLAYER DAMAGE vs ENEMY HP by level ===');
 console.log('(model: every stat level = global level; 1 pull-up rep; campaign enemy base_hp=1200 tier1)');
 console.log('lvl | dmg/rep(noCrit) | dmg/rep(expCrit) | enemyHP | reps-to-kill(expCrit) | dmg growth×  | HP growth×');
@@ -51,7 +57,7 @@ let prevDmg = null, prevHp = null;
 for (const L of [1, 5, 10, 20, 30, 50, 75, 100]) {
   const d = damagePerRep(L);
   const dCrit = d * expectedCritMultiplier(L);
-  const hp = scaleEnemyHp({ base_hp: 1200, tier: 1, scaling: {} }, null, L, 0);
+  const hp = scaleEnemyHp({ base_hp: 1200, tier: 1, scaling: {} }, CAMPAIGN_CONFIG, L, 0);
   const rtk = (hp / dCrit);
   const dg = prevDmg ? (dCrit / prevDmg) : 1;
   const hg = prevHp ? (hp / prevHp) : 1;
@@ -60,7 +66,7 @@ for (const L of [1, 5, 10, 20, 30, 50, 75, 100]) {
   );
   prevDmg = dCrit; prevHp = hp;
 }
-console.log('→ reps-to-kill FALLS as level rises: player damage is superlinear (levelMult=1+L/2, fthScale, flat divineBonus=fth*25), enemy HP is ~linear (1+0.05·L). Enemies melt faster the further you get.\n');
+console.log('→ reps-to-kill still FALLS as level rises, but far more slowly since the HP curve went quadratic (1+0.06·L+0.03·L²). The residual slide is structural: expected damage grows ~L⁴ because critMult = 2+dex·0.1 is UNCAPPED (deliberately left alone, 2026-07-27), and no polynomial HP term can track that. The quadratic is tuned to land the 25-40 reps-to-kill band on L8-L15, where the playerbase actually is; beyond ~L30 enemies still melt.\n');
 
 console.log('=== 2) FLAT DIVINE BONUS (FE snowball) share of per-rep damage ===');
 console.log('(divineBonus = fth_lvl * 25, added flat per rep BEFORE multipliers stack)');

--- a/backend/tests/enemy-hp-curve.test.mjs
+++ b/backend/tests/enemy-hp-curve.test.mjs
@@ -1,0 +1,67 @@
+// Pure-function tests for the campaign enemy HP curve. No DB, no env.
+//
+// The level term went quadratic in the 2026-07 rebalance (`1 + a·L + b·L²`) because
+// player damage is superlinear and a linear HP curve made enemies melt faster the
+// further you got. These pin the shape and the tuning knobs, since a silent change
+// here rebalances the whole campaign.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scaleEnemyHp } from '../utils/campaignEngine.js';
+
+const enemy = (over = {}) => ({ base_hp: 1200, tier: 1, scaling: {}, ...over });
+// Mirrors config.hp of backend/data/campaigns/main-campaign.json.
+const CFG = {
+  hp: { base_per_level: 0.06, quad_per_level: 0.03, tier_mult: [1, 1.8, 3, 6, 12], prestige_mult: 1.5 },
+};
+
+test('HP follows base·(1 + a·L + b·L²)·tierMult·prestigeMult', () => {
+  for (const L of [1, 5, 10, 20, 50]) {
+    const expected = Math.round(1200 * (1 + 0.06 * L + 0.03 * L * L));
+    assert.equal(scaleEnemyHp(enemy(), CFG, L, 0), expected, `level ${L}`);
+  }
+});
+
+test('the quadratic term dominates as level rises (it is what tracks player damage)', () => {
+  const linearOnly = (L) => Math.round(1200 * (1 + 0.06 * L));
+  // At level 1 the quadratic barely registers; by level 50 it is the whole curve.
+  assert.ok(scaleEnemyHp(enemy(), CFG, 1, 0) / linearOnly(1) < 1.05);
+  assert.ok(scaleEnemyHp(enemy(), CFG, 50, 0) / linearOnly(50) > 15);
+});
+
+test('HP is strictly increasing in player level', () => {
+  let prev = 0;
+  for (let L = 1; L <= 100; L++) {
+    const hp = scaleEnemyHp(enemy(), CFG, L, 0);
+    assert.ok(hp > prev, `HP must grow at level ${L} (got ${hp} after ${prev})`);
+    prev = hp;
+  }
+});
+
+test('the quadratic coefficient is tunable per campaign and per enemy', () => {
+  const softer = { hp: { ...CFG.hp, quad_per_level: 0 } };
+  assert.equal(scaleEnemyHp(enemy(), softer, 20, 0), Math.round(1200 * (1 + 0.06 * 20)));
+
+  // A per-enemy `scaling` override wins over the campaign config.
+  const override = enemy({ scaling: { hp_quad_per_level: 0.1 } });
+  assert.equal(scaleEnemyHp(override, CFG, 20, 0), Math.round(1200 * (1 + 0.06 * 20 + 0.1 * 400)));
+});
+
+test('code default matches the shipped campaign JSON when config lacks the key', () => {
+  // An already-seeded DB may hold a campaign row predating `quad_per_level`; the
+  // fallback must produce the same curve as the JSON, not a different one.
+  const legacyCfg = { hp: { base_per_level: 0.06, tier_mult: [1, 1.8, 3, 6, 12], prestige_mult: 1.5 } };
+  assert.equal(scaleEnemyHp(enemy(), legacyCfg, 20, 0), scaleEnemyHp(enemy(), CFG, 20, 0));
+});
+
+test('tier and prestige multipliers still stack on top of the level curve', () => {
+  const lvl = 1 + 0.06 * 10 + 0.03 * 100;
+  assert.equal(scaleEnemyHp(enemy({ tier: 3 }), CFG, 10, 0), Math.round(1200 * lvl * 3));
+  assert.equal(scaleEnemyHp(enemy(), CFG, 10, 2), Math.round(1200 * lvl * 1.5 * 1.5));
+});
+
+test('degenerate inputs stay clamped to at least 1 HP', () => {
+  assert.equal(scaleEnemyHp(enemy({ base_hp: 0 }), CFG, 1, 0), Math.round(1000 * (1 + 0.06 + 0.03)));
+  assert.ok(scaleEnemyHp(enemy(), CFG, 0, 0) >= 1);
+  assert.ok(scaleEnemyHp(enemy(), CFG, -5, 0) >= 1);
+  assert.ok(scaleEnemyHp(enemy(), null, 10, 0) >= 1); // no campaign config at all
+});

--- a/backend/utils/campaignEngine.js
+++ b/backend/utils/campaignEngine.js
@@ -15,17 +15,29 @@ import { getPerkBonuses } from './perks.js';
 /**
  * Scale an enemy's HP for a given player. Prefers per-enemy `scaling`, falling
  * back to the campaign-wide `config.hp`.
+ *
+ * The level term is QUADRATIC (`1 + a·L + b·L²`, audit 2026-07): player damage is
+ * superlinear (levelMult, fthScale, and an uncapped `critMult = 2 + dex·0.1`), so a
+ * linear HP curve made enemies melt faster the further you got. `b` is tunable per
+ * campaign (`config.hp.quad_per_level`) or per enemy (`scaling.hp_quad_per_level`)
+ * so rebalancing is a data change, not a deploy. HP is snapshotted on engage, so
+ * changing these numbers never affects a battle already in progress.
  */
 export function scaleEnemyHp(enemy, campaignConfig, playerLevel, prestige = 0) {
   const base = Number(enemy.base_hp) || 1000;
   const sc = enemy.scaling || {};
   const cfg = (campaignConfig && campaignConfig.hp) || {};
   const perLevel = sc.hp_per_level ?? cfg.base_per_level ?? 0.05;
+  // Default matches config.hp.quad_per_level in main-campaign.json on purpose: the
+  // campaign row in an already-seeded DB may predate that key, and falling back to a
+  // different number would make the shipped curve depend on whether the seed was re-run.
+  const quadPerLevel = sc.hp_quad_per_level ?? cfg.quad_per_level ?? 0.03;
   const tierArr = Array.isArray(cfg.tier_mult) ? cfg.tier_mult : null;
   const tierMult = sc.hp_tier_mult ?? (tierArr ? (tierArr[(enemy.tier || 1) - 1] ?? 1) : 1);
   const prestigeMult = Math.pow(cfg.prestige_mult ?? 1.5, prestige || 0);
   const lvl = Math.max(1, Number(playerLevel) || 1);
-  return Math.max(1, Math.round(base * (1 + lvl * perLevel) * tierMult * prestigeMult));
+  const levelScale = 1 + lvl * perLevel + lvl * lvl * quadPerLevel;
+  return Math.max(1, Math.round(base * levelScale * tierMult * prestigeMult));
 }
 
 /** The player's current active run (joined with its campaign), or null. */

--- a/docs/economy-curves-2026-07.md
+++ b/docs/economy-curves-2026-07.md
@@ -15,24 +15,49 @@ esperado se reporta aparte.
 
 ---
 
-## 1. Daño del jugador vs HP enemigo (la curva de dificultad rota)
+## 1. Daño del jugador vs HP enemigo (la curva de dificultad)
+
+> **Actualizado 2026-07-28**: el HP enemigo pasó de lineal a **cuadrático**
+> (`1 + 0.06·L + 0.03·L²`, `scaleEnemyHp` en `backend/utils/campaignEngine.js`).
+> La tabla de abajo ya refleja la fórmula nueva; las cifras de daño incorporan
+> también el nerf del bono divino (#326, ×25→×5), por eso son más bajas que en la
+> versión original de este documento.
 
 | lvl | dmg/rep (sin crit) | dmg/rep (crit esperado) | HP enemigo | reps-para-matar |
 |----:|----:|----:|----:|----:|
-| 1   | 30     | 31      | 1260 | 40.66 |
-| 5   | 143    | 175     | 1500 | 8.56 |
-| 10  | 300    | 480     | 1800 | 3.75 |
-| 20  | 710    | 1 988   | 2400 | 1.21 |
-| 30  | 1 365  | 5 733   | 3000 | 0.52 |
-| 50  | 4 409  | 25 572  | 4200 | 0.16 |
-| 75  | 16 403 | 127 943 | 5700 | 0.04 |
-| 100 | 50 695 | 496 811 | 7200 | 0.01 |
+| 1   | 10     | 10      | 1 308   | 126.62 |
+| 5   | 43     | 53      | 2 460   | 46.70 |
+| 10  | 100    | 160     | 5 520   | 34.50 |
+| 20  | 310    | 868     | 17 040  | 19.63 |
+| 30  | 765    | 3 213   | 35 760  | 11.13 |
+| 50  | 3 409  | 19 772  | 94 800  | 4.79 |
+| 75  | 14 903 | 116 243 | 209 100 | 1.80 |
+| 100 | 48 695 | 477 211 | 368 400 | 0.77 |
 
-**Las reps-para-matar caen de ~41 (nivel 1) a ~0.01 (nivel 100).** El daño del jugador es superlineal
-(`levelMult = 1 + L/2`, `fthScale`, `divineBonus = fth·25` plano por rep, y el crit multiplicando encima),
-mientras el HP enemigo escala ~lineal (`1 + 0.05·L`). Los enemigos se derriten más cuanto más avanzas —
-justo lo contrario de una curva de dificultad. **El HP debería escalar con el daño esperado del jugador**,
-no lineal por nivel.
+**Las reps-para-matar siguen cayendo con el nivel, pero mucho más despacio** (antes de
+la curva cuadrática: 123 → 0.02; ahora: 127 → 0.77). El coeficiente `b = 0.03` está
+elegido para dejar la banda objetivo de **25-40 reps** sobre los **niveles 8-15**, que es
+donde vive la base de usuarios real.
+
+**Por qué no se puede cubrir todo el rango:** el daño esperado crece ≈`L⁴` porque
+`critMult = 2 + dex·0.1` no tiene tope (decisión explícita de 2026-07-27: no se toca el
+crítico). Ningún término polinómico de HP puede seguir a esa curva, así que por encima de
+~L30 los enemigos se siguen derritiendo. Cerrar ese tramo exige capar el crítico, no más HP.
+
+**Los dos extremos siguen mal, y no los arregla este coeficiente:**
+- **Nivel 1 = ~127 reps para matar**, muy duro para el primer enemigo. Se corrige bajando
+  `base_hp` de los enemigos iniciales, no tocando la curva (el término cuadrático es
+  despreciable a nivel 1).
+- **Nivel >50** sigue siendo trivial (crítico sin tope).
+
+**Aviso de modelo:** la tabla asume *todos los stats = nivel global, sin gear ni pociones*.
+Los datos reales de producción (ver la sección de curva de daño en `auditoria-2026-07-tasks.md`)
+muestran a un jugador de nivel global 12 pegando ~5.000/rep frente a los ~250 que predice el
+modelo — sus stats de combate van muy por encima de su nivel global. **Es decir: en la
+práctica las reps-para-matar reales son bastante más bajas que las de esta tabla.** Por eso
+`quad_per_level` es un valor de configuración (`config.hp.quad_per_level` en
+`main-campaign.json`, override por enemigo con `scaling.hp_quad_per_level`) y no una
+constante: subirlo es un cambio de datos, no un deploy.
 
 ## 2. Bola de nieve de FE (Fe/`fth`)
 
@@ -91,7 +116,9 @@ número exacto es de Roman (ver ⏸️ en el fichero de tasks).
 1. **Cap a la racha** — necesario; da igual la fórmula, cualquiera acota los 5000/día. §4.
 2. **Bajar EV de la ruleta 4h** — 426/día pasivos por clicar. Reducir pesos de premios altos o subир cooldown. §3.
 3. **Domar FE** — el bono plano `fth·25/rep` es el 80%+ del daño temprano y se autoalimenta. §2.
-4. **Curva de dificultad** — HP enemigo debe escalar con el daño esperado, no lineal. §1.
+4. ~~**Curva de dificultad** — HP enemigo debe escalar con el daño esperado, no lineal.~~ §1.
+   **Hecho (2026-07-28)**: HP cuadrático `1 + 0.06·L + 0.03·L²`. Queda abierto el tramo alto
+   (requiere capar el crítico) y el arranque duro de nivel 1 (requiere bajar `base_hp`).
 5. **Pociones DEX de crit / prestigio ROI** — no modeladas aquí en detalle; el crit esperado de §1 ya muestra
    cuánto multiplica el crit (a nivel 100, ×~10 sobre el daño sin crit).
 


### PR DESCRIPTION
Implementa **"Arreglar la curva de dificultad"** (P1 — Rebalance económico), según lo resuelto el 2026-07-27: **solo HP, no se toca el crítico**.

`scaleEnemyHp` (`backend/utils/campaignEngine.js:19`) pasa de lineal a cuadrático:

```
base · (1 + 0.06·L + 0.03·L²) · tierMult · prestigeMult
```

El coeficiente cuadrático es **configurable**: `config.hp.quad_per_level` en `main-campaign.json`, con override por enemigo vía `scaling.hp_quad_per_level`. Reafinarlo es un cambio de datos, no un deploy.

> **Detalle importante**: el default en código se fija a `0.03`, el mismo valor que el JSON, a propósito. La fila de `campaigns` en una BD ya sembrada puede no tener la clave `quad_per_level` (el seed solo la escribe si se re-ejecuta), y un fallback distinto haría que la curva que corre en prod dependiera de si alguien lanzó el seed o no. Hay un test que fija esa equivalencia.

## Calibración — y dónde no llega

Me pediste afinar el coeficiente contra `docs/economy-curves-2026-07.md` para dejar el coste en ~25-40 reps. **Ningún coeficiente cuadrático consigue eso en todo el rango**, y creo que merece la pena que lo veas antes de mergear. Barrido con la función de daño real:

| b | L1 | L5 | L10 | L15 | L20 | L30 | L50 | L100 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 0.005 *(el número de partida)* | 124 | 33 | 16 | 9 | 6 | 3 | 1.0 | 0.1 |
| 0.02 | 126 | 41 | 27 | 20 | 14 | 8 | 3.3 | 0.5 |
| **0.03 (elegido)** | 127 | 47 | **35** | **27** | 20 | 11 | 4.8 | 0.8 |
| 0.05 | 129 | 58 | 50 | 40 | 31 | 18 | 7.8 | 1.3 |

La causa es estructural: **el daño esperado crece ≈`L⁴`** porque `critMult = 2 + dex·0.1` no tiene tope (decisión explícita tuya de no tocarlo). Ninguna parábola sigue a una cuártica. Así que elegí `b = 0.03`, que centra la banda de 25-40 en **L8-L15** — donde está la base de usuarios real (el veterano de la investigación de daño es nivel global 12).

**Dos extremos que este cambio no arregla** (fuera del alcance de la decisión, los dejo apuntados y no los toco):
- **Nivel 1 sigue costando ~127 reps.** El término cuadrático es despreciable ahí; el arranque duro se corrige bajando `base_hp` de los primeros enemigos.
- **Por encima de ~L50 los enemigos se siguen derritiendo.** Eso solo se cierra capando el crítico.

**Aviso sobre el modelo**: la tabla asume *todos los stats = nivel global, sin gear ni pociones*. Los datos reales que investigaste muestran a un jugador de nivel global 12 pegando ~5.000/rep frente a los ~250 del modelo (sus stats de combate van muy por encima de su nivel global) — o sea que **en la práctica las reps reales serán bastante menores que las de la tabla**. Si al probarlo lo notas blando, subir `quad_per_level` en el JSON es una línea.

## Verificación: **integración local parcial** (tests + análisis; sin flujo HTTP)

- **8 tests nuevos** en `backend/tests/enemy-hp-curve.test.mjs`: forma exacta de la fórmula, dominancia del término cuadrático, monotonía estricta en L1-100, overrides de campaña y de enemigo, equivalencia default-código ↔ JSON, apilado de tier/prestigio, y entradas degeneradas (base_hp 0, nivel 0/negativo, config nula). `npm test`: **19 pasan, 0 fallan** (2 skips preexistentes, los de concurrencia que piden `DATABASE_URL`).
- `node scripts/analyze_economy_curves.js` ejecutado con la fórmula nueva; tabla y conclusiones de `docs/economy-curves-2026-07.md` regeneradas con los números reales (los viejos eran anteriores al nerf de #326).
- **Revisado a mano que no rompe batallas en curso**: `scaleEnemyHp` solo se invoca en el engage (`campaignEngine.js:161`) y el resultado se persiste en `user_node_progress.enemy_total_hp`; un nodo ya `engaged` con HP > 0 retorna antes de recalcular (`:154`).
- `node --check` en los `.js` tocados + validación del JSON de campaña.
- No hay cambios de frontend. No se tocó producción ni la BD real.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNEe7PaSrajFNupFZFSqL1)_