### PR TITLE
feat(prestigio): títulos exclusivos «Renacido I…V» + flag `is_exclusive`

### DIFF
--- a/backend/boss.js
+++ b/backend/boss.js
@@ -280,7 +280,7 @@ router.post('/open-chest', authenticate, async (req, res) => {
         let itemRes = await client.query(`
             SELECT * FROM items
             WHERE rarity = $1
-            AND type != 'bundle'
+            AND type != 'bundle' AND is_exclusive IS NOT TRUE
             AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $2 AND item_id = items.id)
             ORDER BY RANDOM() LIMIT 1
         `, [targetRarity, userId]);
@@ -297,7 +297,7 @@ router.post('/open-chest', authenticate, async (req, res) => {
             // User owns all items of this rarity. Try to find ANY unowned item.
             let fallbackRes = await client.query(`
                 SELECT * FROM items
-                WHERE type != 'bundle'
+                WHERE type != 'bundle' AND is_exclusive IS NOT TRUE
                 AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $1 AND item_id = items.id)
                 ORDER BY RANDOM() LIMIT 1
             `, [userId]);
@@ -314,7 +314,7 @@ router.post('/open-chest', authenticate, async (req, res) => {
                 // User owns EVERYTHING? Give gold compensation proportional to price of a random item of targetRarity
                 const priceRes = await client.query(`
                     SELECT price FROM items
-                    WHERE rarity = $1 AND type != 'bundle'
+                    WHERE rarity = $1 AND type != 'bundle' AND is_exclusive IS NOT TRUE
                     ORDER BY RANDOM() LIMIT 1
                 `, [targetRarity]);
 
@@ -335,7 +335,7 @@ router.post('/open-chest', authenticate, async (req, res) => {
       await client.query('UPDATE users SET reppy_coins = reppy_coins + $1 WHERE id = $2', [totalCoins, userId]);
 
       // Reel items for legacy animation support
-      const dummiesRes = await client.query(`SELECT name, type, rarity FROM items WHERE type != 'bundle' ORDER BY RANDOM() LIMIT 40`);
+      const dummiesRes = await client.query(`SELECT name, type, rarity FROM items WHERE type != 'bundle' AND is_exclusive IS NOT TRUE ORDER BY RANDOM() LIMIT 40`);
 
       return { status: 200, rewards, totalCoins, reelItems: dummiesRes.rows };
     });
@@ -389,7 +389,7 @@ router.post('/open-legendary-chest', authenticate, async (req, res) => {
       // 2. GUARANTEED LEGENDARY ITEM
       let legItemRes = await client.query(`
         SELECT * FROM items
-        WHERE rarity = 'legendary' AND type != 'bundle'
+        WHERE rarity = 'legendary' AND type != 'bundle' AND is_exclusive IS NOT TRUE
         AND is_seasonal = TRUE
         AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $1 AND item_id = items.id)
         ORDER BY RANDOM() LIMIT 1
@@ -417,7 +417,7 @@ router.post('/open-legendary-chest', authenticate, async (req, res) => {
 
           let itemRes = await client.query(`
               SELECT * FROM items
-              WHERE rarity = $1 AND type != 'bundle'
+              WHERE rarity = $1 AND type != 'bundle' AND is_exclusive IS NOT TRUE
               AND is_seasonal = TRUE
               AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $2 AND item_id = items.id)
               ORDER BY RANDOM() LIMIT 1
@@ -436,7 +436,7 @@ router.post('/open-legendary-chest', authenticate, async (req, res) => {
 
       await client.query('UPDATE users SET reppy_coins = reppy_coins + $1 WHERE id = $2', [totalCoins, userId]);
 
-      const dummiesRes = await client.query(`SELECT name, type, rarity FROM items WHERE type != 'bundle' ORDER BY RANDOM() LIMIT 40`);
+      const dummiesRes = await client.query(`SELECT name, type, rarity FROM items WHERE type != 'bundle' AND is_exclusive IS NOT TRUE ORDER BY RANDOM() LIMIT 40`);
 
       return { status: 200, rewards, totalCoins, reelItems: dummiesRes.rows };
     });
@@ -488,7 +488,7 @@ router.post('/open-epic-chest', authenticate, async (req, res) => {
       // 2. GUARANTEED SPECIAL ITEM
       let epicItemRes = await client.query(`
         SELECT * FROM items
-        WHERE rarity = 'especial' AND type != 'bundle'
+        WHERE rarity = 'especial' AND type != 'bundle' AND is_exclusive IS NOT TRUE
         AND is_seasonal = TRUE
         AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $1 AND item_id = items.id)
         ORDER BY RANDOM() LIMIT 1
@@ -515,7 +515,7 @@ router.post('/open-epic-chest', authenticate, async (req, res) => {
 
           let itemRes = await client.query(`
               SELECT * FROM items
-              WHERE rarity = $1 AND type != 'bundle'
+              WHERE rarity = $1 AND type != 'bundle' AND is_exclusive IS NOT TRUE
               AND is_seasonal = TRUE
               AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $2 AND item_id = items.id)
               ORDER BY RANDOM() LIMIT 1
@@ -533,7 +533,7 @@ router.post('/open-epic-chest', authenticate, async (req, res) => {
 
       await client.query('UPDATE users SET reppy_coins = reppy_coins + $1 WHERE id = $2', [totalCoins, userId]);
 
-      const dummiesRes = await client.query(`SELECT name, type, rarity FROM items WHERE type != 'bundle' ORDER BY RANDOM() LIMIT 40`);
+      const dummiesRes = await client.query(`SELECT name, type, rarity FROM items WHERE type != 'bundle' AND is_exclusive IS NOT TRUE ORDER BY RANDOM() LIMIT 40`);
 
       return { status: 200, rewards, totalCoins, reelItems: dummiesRes.rows };
     });
@@ -583,7 +583,7 @@ router.post('/open-level-chest', authenticate, async (req, res) => {
       const itemRes = await client.query(`
         SELECT * FROM items
         WHERE rarity IN ('common', 'rare')
-        AND type != 'bundle'
+        AND type != 'bundle' AND is_exclusive IS NOT TRUE
         AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $1 AND item_id = items.id)
         ORDER BY RANDOM() LIMIT 1
       `, [userId]);

--- a/backend/data/prestigeTitles.js
+++ b/backend/data/prestigeTitles.js
@@ -1,0 +1,57 @@
+/**
+ * Títulos exclusivos de prestigio — la recompensa de cada vuelta de New Game+.
+ *
+ * Set FIJO de 5: NG+1 → Renacido I … NG+5 → Renacido V. A partir de NG+6 no hay
+ * cosmético nuevo (decisión de Roman, 2026-07-27). No se compran, no se venden y
+ * no pueden salir de un cofre: viven en `items` con `is_exclusive = TRUE`, que es
+ * lo que filtran la tienda, la rotación diaria y las queries de loot por rareza.
+ *
+ * `css_value` es un NOMBRE DE CLASE CSS (los títulos se pintan con `:class`, no
+ * con estilo inline) — definidas en `frontend/src/cosmetics.css`. La escala visual
+ * va bronce → plata → oro → carmesí → prismático.
+ *
+ * Esta lista es la fuente única: la consumen el seed
+ * (`backend/scripts/seed_prestige_titles.js`) y el grant de `prestige()`.
+ */
+export const PRESTIGE_TITLES = [
+  {
+    prestigeLevel: 1,
+    name: 'Renacido I',
+    description: 'Completaste la campaña y volviste a empezar. La primera de muchas vueltas.',
+    rarity: 'rare',
+    cssValue: 'title-renacido-i',
+  },
+  {
+    prestigeLevel: 2,
+    name: 'Renacido II',
+    description: 'Dos campañas a la espalda. Ya no es casualidad.',
+    rarity: 'especial',
+    cssValue: 'title-renacido-ii',
+  },
+  {
+    prestigeLevel: 3,
+    name: 'Renacido III',
+    description: 'Tres vueltas. El camino se te ha quedado corto tres veces.',
+    rarity: 'especial',
+    cssValue: 'title-renacido-iii',
+  },
+  {
+    prestigeLevel: 4,
+    name: 'Renacido IV',
+    description: 'Cuatro renacimientos. Muy pocos llegan hasta aquí.',
+    rarity: 'legendary',
+    cssValue: 'title-renacido-iv',
+  },
+  {
+    prestigeLevel: 5,
+    name: 'Renacido V',
+    description: 'Cinco vueltas completas. No queda nada de la campaña que no hayas roto.',
+    rarity: 'calistenico',
+    cssValue: 'title-renacido-v',
+  },
+];
+
+/** El título que corresponde a una vuelta de prestigio, o null si ya no hay más. */
+export function titleForPrestigeLevel(level) {
+  return PRESTIGE_TITLES.find((t) => t.prestigeLevel === Number(level)) || null;
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -763,6 +763,10 @@ async function ensureSchemaMigrations() {
     // Revocación de JWT: subir `token_version` invalida todos los tokens vivos de
     // ese usuario (logout global, ban, cambio de rol). Lo compara middleware.js.
     await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER DEFAULT 0');
+    // Cosméticos exclusivos (títulos de prestigio): no se compran, no se venden y
+    // no pueden salir de un cofre — solo se otorgan al prestigiar. Lo consultan la
+    // tienda, la rotación diaria y TODAS las queries de loot por rareza.
+    await query('ALTER TABLE items ADD COLUMN IF NOT EXISTS is_exclusive BOOLEAN DEFAULT FALSE');
     // Per-user "feature seen" flags that drive the NEW badges/dots.
     await query(`CREATE TABLE IF NOT EXISTS user_feature_seen (
         user_id     VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/scripts/seed_prestige_titles.js
+++ b/backend/scripts/seed_prestige_titles.js
@@ -1,0 +1,46 @@
+import { query } from '../db.js';
+import { PRESTIGE_TITLES } from '../data/prestigeTitles.js';
+
+// Siembra los 5 títulos exclusivos de prestigio en la tabla `items`.
+//
+// Hace falta un seed (y no solo un JSON) porque los cosméticos viven en la BD:
+// `users.equipped_title_id` referencia `items(id)`, así que un título que no esté
+// en `items` no se puede ni otorgar ni equipar.
+//
+// Idempotente: `ON CONFLICT (name)` reescribe la definición, así que re-ejecutarlo
+// tras retocar textos o estilos actualiza sin duplicar ni tocar quién los tiene.
+//
+// Uso: node backend/scripts/seed_prestige_titles.js
+async function seed() {
+  // El seed puede correr antes de que arranque el backend (que es quien aplica la
+  // migración), así que se asegura la columna aquí también.
+  await query('ALTER TABLE items ADD COLUMN IF NOT EXISTS is_exclusive BOOLEAN DEFAULT FALSE');
+
+  for (const t of PRESTIGE_TITLES) {
+    const res = await query(
+      `INSERT INTO items (name, description, type, rarity, css_value, price, price_gems, is_exclusive, is_customizable)
+       VALUES ($1, $2, 'title', $3, $4, 0, 0, TRUE, TRUE)
+       ON CONFLICT (name) DO UPDATE SET
+         description = EXCLUDED.description,
+         type = EXCLUDED.type,
+         rarity = EXCLUDED.rarity,
+         css_value = EXCLUDED.css_value,
+         price = 0,
+         price_gems = 0,
+         is_exclusive = TRUE
+       RETURNING id, name`,
+      [t.name, t.description, t.rarity, t.cssValue]
+    );
+    console.log(`✅ NG+${t.prestigeLevel} → "${res.rows[0].name}" (item ${res.rows[0].id}, ${t.rarity})`);
+  }
+}
+
+seed()
+  .then(() => {
+    console.log(`${PRESTIGE_TITLES.length} títulos de prestigio sembrados.`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Error sembrando los títulos de prestigio:', err);
+    process.exit(1);
+  });

--- a/backend/shop.js
+++ b/backend/shop.js
@@ -41,6 +41,7 @@ router.get('/cosmetics', authenticate, async (req, res) => {
       FROM items i
       LEFT JOIN user_items ui ON i.id = ui.item_id AND ui.user_id = $1
       WHERE (i.is_customizable = true OR i.type IN ('bundle', 'consumable'))
+        AND i.is_exclusive IS NOT TRUE
       ORDER BY i.type ASC, i.id ASC
     `, [req.user.id]);
     const inventoryRes = await query('SELECT item_id, is_new, quantity FROM user_items WHERE user_id = $1', [req.user.id]);
@@ -394,6 +395,13 @@ router.post('/buy/:id', authenticate, economyLimiter, async (req, res) => {
     const itemRes = await query('SELECT * FROM items WHERE id = $1', [itemId]);
     if (itemRes.rows.length === 0) return res.status(404).json({ message: 'Item not found' });
     const item = itemRes.rows[0];
+
+    // Guard: exclusive cosmetics (títulos de prestigio) never go through the shop,
+    // whatever price they happen to carry. Explicit so it doesn't silently depend on
+    // the 0/0 price check below.
+    if (item.is_exclusive) {
+      return res.status(400).json({ message: 'ERROR: UNIT EXCLUSIVE - NOT FOR SALE' });
+    }
 
     // Guard: an item with no price in either currency is not for sale.
     // (Bundles you already own can still net to 0 via the refund logic below,

--- a/backend/utils/bossRewards.js
+++ b/backend/utils/bossRewards.js
@@ -128,7 +128,7 @@ export async function grantLastHitBonus(userId, bossId, client = null) {
       const itemRes = await q(`
         SELECT * FROM items 
         WHERE rarity IN ('rare', 'especial') 
-        AND type != 'bundle'
+        AND type != 'bundle' AND is_exclusive IS NOT TRUE
         AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $1 AND item_id = items.id)
         ORDER BY RANDOM() LIMIT 1
       `, [userId]);

--- a/backend/utils/campaignEngine.js
+++ b/backend/utils/campaignEngine.js
@@ -11,6 +11,7 @@ import { calculateDamage } from './damage.js';
 import { sendToUser } from '../socketManager.js';
 import { emitProgress } from './progressEvents.js';
 import { getPerkBonuses } from './perks.js';
+import { titleForPrestigeLevel } from '../data/prestigeTitles.js';
 
 /**
  * Scale an enemy's HP for a given player. Prefers per-enemy `scaling`, falling
@@ -378,7 +379,43 @@ export async function prestige(client, userId) {
     [userId, run.campaign_id, newLevel]
   );
 
-  return { status: 200, body: { message: '¡Prestigio alcanzado!', prestige_level: newLevel } };
+  const title = await grantPrestigeTitle(client, userId, newLevel);
+
+  return { status: 200, body: { message: '¡Prestigio alcanzado!', prestige_level: newLevel, title } };
+}
+
+/**
+ * Grant the exclusive title for a prestige turn (NG+1 → Renacido I … NG+5 → V).
+ * Beyond the 5th turn there is no new cosmetic, by design.
+ *
+ * Best-effort, behind a SAVEPOINT: losing a whole New Game+ because a cosmetic
+ * failed to grant would be far worse than not getting the cosmetic. The savepoint
+ * matters — a plain try/catch would not help, since any failed statement leaves the
+ * surrounding transaction aborted and the COMMIT would roll the prestige back too.
+ * Returns the granted title (or null), so the caller can show it.
+ */
+async function grantPrestigeTitle(client, userId, prestigeLevel) {
+  const def = titleForPrestigeLevel(prestigeLevel);
+  if (!def) return null;
+
+  await client.query('SAVEPOINT prestige_title');
+  try {
+    const granted = await client.query(
+      `INSERT INTO user_items (user_id, item_id, is_new)
+       SELECT $1, id, TRUE FROM items WHERE name = $2 AND is_exclusive = TRUE
+       ON CONFLICT (user_id, item_id) DO NOTHING
+       RETURNING item_id`,
+      [userId, def.name]
+    );
+    await client.query('RELEASE SAVEPOINT prestige_title');
+    // rowCount 0 = el título aún no está sembrado, o el usuario ya lo tenía.
+    if (granted.rowCount === 0) return null;
+    return { id: granted.rows[0].item_id, name: def.name, css_value: def.cssValue, rarity: def.rarity };
+  } catch (err) {
+    await client.query('ROLLBACK TO SAVEPOINT prestige_title');
+    console.error('[prestige] No se pudo otorgar el título exclusivo:', err.message);
+    return null;
+  }
 }
 
 /**
@@ -586,7 +623,7 @@ async function grantEnemyLoot(client, userId, enemyLoot, prestige, campaignConfi
   if (rarity) {
     const itemRes = await client.query(
       `SELECT * FROM items
-       WHERE rarity = $1 AND type != 'bundle'
+       WHERE rarity = $1 AND type != 'bundle' AND is_exclusive IS NOT TRUE
        AND NOT EXISTS (SELECT 1 FROM user_items WHERE user_id = $2 AND item_id = items.id)
        ORDER BY RANDOM() LIMIT 1`,
       [rarity, userId]

--- a/backend/utils/shop_rotation.js
+++ b/backend/utils/shop_rotation.js
@@ -20,7 +20,7 @@ export const rotateDailyShop = async (userId = null) => {
     console.log('Rotating Daily Shop...');
     
     // 1. Fetch eligible items (exclude bundles and customizable)
-    const itemsRes = await query('SELECT id, price, price_gems, rarity, is_seasonal FROM items WHERE type != \'bundle\' AND is_customizable = false');
+    const itemsRes = await query('SELECT id, price, price_gems, rarity, is_seasonal FROM items WHERE type != \'bundle\' AND is_customizable = false AND is_exclusive IS NOT TRUE');
     const allItems = itemsRes.rows;
     
     if (allItems.length === 0) {

--- a/frontend/src/cosmetics.css
+++ b/frontend/src/cosmetics.css
@@ -374,3 +374,85 @@
   text-shadow: none;
   filter: drop-shadow(0 0 8px rgba(167, 139, 250, 0.6));
 }
+
+/* ========================================
+   TÍTULOS EXCLUSIVOS DE PRESTIGIO (Renacido I…V)
+   Uno por vuelta de prestigio; no se compran ni caen de cofres.
+   La escala es bronce → plata → oro → carmesí → prismático.
+   ======================================== */
+.title-renacido-i {
+  background: linear-gradient(to right, #7c4a20, #cd7f32, #7c4a20);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 900;
+  text-transform: uppercase;
+  text-shadow: 0 0 8px rgba(205, 127, 50, 0.35);
+  animation: title-renacido-flow 4s linear infinite;
+}
+
+.title-renacido-ii {
+  background: linear-gradient(to right, #8a9199, #e8eef4, #8a9199);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 900;
+  text-transform: uppercase;
+  text-shadow: 0 0 10px rgba(232, 238, 244, 0.4);
+  animation: title-renacido-flow 3.5s linear infinite;
+}
+
+.title-renacido-iii {
+  background: linear-gradient(to right, #b8860b, #ffd700, #fff3b0, #ffd700, #b8860b);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 900;
+  text-transform: uppercase;
+  text-shadow: 0 0 12px rgba(255, 215, 0, 0.5);
+  animation: title-renacido-flow 3s linear infinite;
+}
+
+.title-renacido-iv {
+  background: linear-gradient(to right, #6b0f1a, #dc143c, #ff6b81, #dc143c, #6b0f1a);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-style: italic;
+  text-shadow: 0 0 14px rgba(220, 20, 60, 0.55);
+  animation: title-renacido-flow 2.5s linear infinite;
+}
+
+.title-renacido-v {
+  background: linear-gradient(to right, #ff0080, #ff8c00, #ffed00, #00e5a0, #00b3ff, #a855f7, #ff0080);
+  background-size: 300% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-style: italic;
+  filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.6));
+  animation: title-renacido-flow 2s linear infinite;
+}
+
+@keyframes title-renacido-flow {
+  to { background-position: 200% center; }
+}
+
+/* Respetar a quien pide menos movimiento: el degradado se queda quieto. */
+@media (prefers-reduced-motion: reduce) {
+  .title-renacido-i,
+  .title-renacido-ii,
+  .title-renacido-iii,
+  .title-renacido-iv,
+  .title-renacido-v {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Implementa **"Prestigio con ROI positivo: cosméticos exclusivos"** (P1 — Rebalance económico), con el contenido que aprobaste el 2026-07-27: set **fijo de 5 títulos**, uno por vuelta (NG+1 → *Renacido I* … NG+5 → *Renacido V*), sin cosmético nuevo a partir de NG+6, y gradientes escalando **bronce → plata → oro → carmesí → prismático**.

## ⚠️ Un desvío de la decisión que necesitas saber

Tu resolución decía «`cosmetics.is_exclusive`» y «`INSERT INTO user_inventory`». **Ese ya no es el camino vivo**, y si lo hubiera implementado así los títulos no se habrían podido ni equipar:

- `users.equipped_title_id` tiene **FK a `items(id)`** (`backend/profile.js:64`), no a `cosmetics`.
- La tienda vende desde **`items`** (`shop.js:41`) y el inventario es **`user_items`**, no `user_inventory`.
- `cosmetics`/`user_inventory` son legacy: solo sobreviven en JOINs de lectura sueltos (`users.js:28`, `leaderboard.js:46`, `social.js:20`, `social_feed.js:477`) que conviven con los de `items`.

Así que la flag va en **`items.is_exclusive`** y el grant a **`user_items`**. El nombre de la flag y todo el contenido son los que elegiste. *(Esos JOINs a `cosmetics` que quedan sueltos son otra cara del drift que ya trackea la task de "unificar las 3 fuentes de esquema" — no los toco aquí.)*

## Qué entra

| Pieza | |
|---|---|
| `backend/data/prestigeTitles.js` (nuevo) | Fuente única de los 5 títulos (nombre, descripción, rareza, clase CSS). La consumen el seed y `prestige()`. |
| `backend/scripts/seed_prestige_titles.js` (nuevo) | Siembra idempotente en `items`. Hace falta un seed y no un JSON: un título que no esté en `items` no se puede otorgar ni equipar. |
| `ensureSchemaMigrations()` | `ALTER TABLE items ADD COLUMN IF NOT EXISTS is_exclusive BOOLEAN DEFAULT FALSE`. |
| `prestige()` | Grant del título de la vuelta correspondiente. |
| `frontend/src/cosmetics.css` | Las 5 clases (los títulos se pintan con `:class`, así que `css_value` es un **nombre de clase**, no CSS inline). |

**Exclusividad de verdad** — no basta con no ponerlo en la tienda, porque los cofres eligen items **por rareza**. Cerrado en todas las vías: catálogo de la tienda, rotación diaria, guarda explícita en `POST /shop/buy/:id`, y las 13 queries de loot por rareza (cofres de boss, loot de campaña, bonus de golpe de gracia).

**Sobre el `SAVEPOINT`**: el grant va detrás de uno. Un `try/catch` pelado no habría servido — en Postgres cualquier sentencia fallida deja la transacción abortada y el `COMMIT` habría tumbado **el prestigio entero**. Perder un New Game+ por un cosmético sería mucho peor que no recibirlo.

## Verificación: **integración local**

Postgres 16 efímero, `schema.sql` + el DDL de `items`/`user_items`, seed ejecutado. Script de verificación con **10 aserciones, todas en verde**:

- Los 5 títulos quedan `type='title'`, `is_exclusive=TRUE`, precio `0/0`.
- La query real de `GET /shop/cosmetics` no los lista; la de la rotación diaria tampoco.
- **300 tiradas de loot de rareza `calistenico`** (donde *Renacido V* competía con un solo señuelo) → **0 filtraciones**. Este era el caso que más me preocupaba: sin el filtro, un cofre alto lo habría soltado.
- NG+1 y NG+5 otorgan su título; un segundo grant del mismo no duplica (`ON CONFLICT`).
- **El `SAVEPOINT` hace lo que dice**: forcé un `INSERT` inválido dentro de la transacción y verifiqué que tras el `ROLLBACK TO SAVEPOINT` la transacción sigue usable y el `COMMIT` del prestigio pasa igual.

Además: `npm run build` del frontend completo (SSG + OG images + fix-seo) OK, con las clases `title-renacido-*` presentes en el CSS emitido; `node --check` en los 8 ficheros tocados.

No se tocó producción ni la BD real.

## Para desplegar
```bash
node backend/scripts/seed_prestige_titles.js
```
(La columna la crea sola el arranque del backend; el seed también la asegura por si se corre antes.)

No hay strings de UI nuevos, así que no hay claves i18n que añadir — el nombre y la descripción del título viven en la BD, como el resto de cosméticos.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNEe7PaSrajFNupFZFSqL1)_