### PR TITLE
balance(boss): HP del boss comunitario = max(50.000, activos × 400)

### DIFF
--- a/backend/tests/boss-hp-scaling.test.mjs
+++ b/backend/tests/boss-hp-scaling.test.mjs
@@ -1,0 +1,40 @@
+// Pure-function tests para el escalado de HP del boss comunitario.
+// El boss sigue siempre activo; lo único que escala es el HP con la comunidad
+// (`max(50.000, activos × 400)`, decisión 2026-07-27).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bossHpForActiveUsers, BASE_BOSS_HP, HP_PER_ACTIVE_USER } from '../utils/boss.js';
+
+test('el suelo de 50.000 manda mientras la comunidad sea pequeña', () => {
+  assert.equal(bossHpForActiveUsers(0), BASE_BOSS_HP);
+  assert.equal(bossHpForActiveUsers(1), BASE_BOSS_HP);
+  assert.equal(bossHpForActiveUsers(100), BASE_BOSS_HP);
+  // 125 × 400 = 50.000 exactos: el punto en el que el escalado alcanza al suelo.
+  assert.equal(bossHpForActiveUsers(125), BASE_BOSS_HP);
+});
+
+test('por encima de ~125 activos el HP escala linealmente', () => {
+  assert.equal(bossHpForActiveUsers(126), 126 * HP_PER_ACTIVE_USER);
+  assert.equal(bossHpForActiveUsers(500), 200000);
+  assert.equal(bossHpForActiveUsers(2000), 800000);
+});
+
+test('nunca devuelve menos que el suelo, pase lo que pase', () => {
+  for (const bad of [-1, -9999, null, undefined, NaN, Infinity, 'abc', {}]) {
+    assert.ok(bossHpForActiveUsers(bad) >= BASE_BOSS_HP, `entrada ${String(bad)}`);
+  }
+});
+
+test('el HP es entero (va a una columna integer)', () => {
+  assert.ok(Number.isInteger(bossHpForActiveUsers(126.7)));
+  assert.ok(Number.isInteger(bossHpForActiveUsers(999.5)));
+});
+
+test('el HP es monótono en el número de activos', () => {
+  let prev = 0;
+  for (let n = 0; n <= 400; n += 7) {
+    const hp = bossHpForActiveUsers(n);
+    assert.ok(hp >= prev, `no debe bajar al subir activos (n=${n})`);
+    prev = hp;
+  }
+});

--- a/backend/utils/boss.js
+++ b/backend/utils/boss.js
@@ -1,8 +1,25 @@
 import { query } from '../db.js';
 
+/** Suelo de HP del boss comunitario: lo que valía antes de escalar por comunidad. */
+export const BASE_BOSS_HP = 50000;
+/** HP que aporta cada usuario activo (reps en los últimos 7 días). */
+export const HP_PER_ACTIVE_USER = 400;
+
+/** HP base del boss comunitario para un número dado de usuarios activos. */
+export function bossHpForActiveUsers(activeUsers) {
+  const n = Number(activeUsers);
+  const safe = Number.isFinite(n) && n > 0 ? n : 0;
+  return Math.max(BASE_BOSS_HP, Math.round(safe * HP_PER_ACTIVE_USER));
+}
+
 /**
- * Recalculates the total HP for all bosses based on the number of active users in the last 7 days.
- * Formula: ActiveUsers * 350 (Min: 350)
+ * Recalculates the total HP for all bosses from the number of active users in the
+ * last 7 days: `max(50.000, activos × 400)`, then ×8 for legendary / ×3 for epic.
+ *
+ * El boss sigue SIEMPRE activo — sin ventanas programadas ni cron (decidido
+ * 2026-07-27). Sólo se recalcula el HP; `start_date`/`end_date` siguen sin uso.
+ * Un boss ya dañado conserva su `current_hp`: subir el techo no le devuelve vida,
+ * para no invalidar el daño que la comunidad ya le hizo.
  */
 export async function syncBossHealth() {
   try {
@@ -16,30 +33,41 @@ export async function syncBossHealth() {
     `);
     
     const activeUsers = parseInt(activeUsersRes.rows[0]?.count) || 0;
-    const newTotalHp = 50000;
-    
-    console.log(`[BOSS_SYNC] Manual override: ${newTotalHp} HP.`);
+
+    // El HP escala con la comunidad para que un veterano no funda el boss solo
+    // (decidido 2026-07-27). El suelo de 50.000 mantiene el valor histórico
+    // mientras la base sea pequeña: sólo empieza a subir por encima de ~125
+    // activos semanales. Los multiplicadores is_legendary (×8) / is_epic (×3)
+    // se aplican encima, en el UPDATE de abajo.
+    const newTotalHp = bossHpForActiveUsers(activeUsers);
+
+    console.log(`[BOSS_SYNC] ${activeUsers} usuarios activos (7d) → ${newTotalHp} HP base.`);
 
     // 2. Update bosses total_hp and current_hp with rarity-based scaling
     // We apply scaling if the boss hasn't been defeated yet
+    // `current_hp` sólo se rellena a tope si el boss estaba intacto; uno ya dañado
+    // conserva su vida para no invalidar el daño que la comunidad ya le hizo.
+    // El LEAST es necesario ahora que el techo es dinámico: si la base de activos
+    // baja, el nuevo total puede quedar por debajo del current_hp de un boss a
+    // medias y la barra se pintaría por encima del 100%.
     await query(`
-      UPDATE boss_fights 
-      SET total_hp = CASE 
-            WHEN is_legendary THEN $1 * 8 
-            WHEN is_epic THEN $1 * 3
-            ELSE $1 
-          END,
-          current_hp = CASE 
-            WHEN current_hp >= total_hp THEN (
-              CASE 
-                WHEN is_legendary THEN $1 * 8 
-                WHEN is_epic THEN $1 * 3
-                ELSE $1 
-              END
-            )
-            ELSE current_hp 
+      UPDATE boss_fights
+      SET total_hp = scaled.hp,
+          current_hp = CASE
+            WHEN boss_fights.current_hp >= boss_fights.total_hp THEN scaled.hp
+            ELSE LEAST(boss_fights.current_hp, scaled.hp)
           END
-      WHERE status != 'defeated'
+      FROM (
+        SELECT id,
+               CASE
+                 WHEN is_legendary THEN $1 * 8
+                 WHEN is_epic THEN $1 * 3
+                 ELSE $1
+               END AS hp
+        FROM boss_fights
+        WHERE status != 'defeated'
+      ) AS scaled
+      WHERE boss_fights.id = scaled.id
     `, [newTotalHp]);
 
     console.log('[BOSS_SYNC] Successfully updated boss health templates.');


### PR DESCRIPTION
Implementa **"Boss comunitario: HP escalado por usuarios activos, SIN ventana ni cron"** (P2), según lo resuelto el 2026-07-27.

`syncBossHealth` (`backend/utils/boss.js`) ya calculaba `activeUsers` (COUNT distinct de `reps` en 7 días) pero **lo descartaba** y ponía `newTotalHp = 50000` a pelo. Ahora:

```js
newTotalHp = max(50.000, activos × 400)
```

con `is_legendary` (×8) / `is_epic` (×3) apilando encima, como hasta ahora. Con la base actual el `max()` lo deja en 50.000 hasta pasar de ~125 activos semanales, así que **el comportamiento no cambia hoy** — solo deja de romperse cuando la comunidad crezca.

Tal y como decidiste: **el boss sigue siempre activo**. Sin ventanas programadas, sin `node-cron`, sin countdown, sin push de anticipación; `start_date`/`end_date` siguen sin uso y no se toca nada de UI.

## Un arreglo que el cambio arrastra

El `UPDATE` de HP lleva ahora un `LEAST`. Con el techo fijo en 50.000 esto no hacía falta: un boss a medias nunca podía tener más vida que su total. Al volverse dinámico sí puede — si la base de activos baja, el nuevo total puede quedar por debajo del `current_hp` de un boss ya empezado y **la barra se pintaría por encima del 100%**. El `LEAST` lo clampa. Sigue intacto lo importante: un boss dañado **no recupera vida** al recalcular, para no invalidar el daño que la comunidad ya le hizo.

## Verificación: **integración local**

Postgres 16 efímero con la tabla `boss_fights` real. Ejercitado el `UPDATE` exacto del código, **7 aserciones en verde**:

- 200 activos → normal 80.000, epic 240.000 (×3), legendary 640.000 (×8).
- Boss dañado (12.000/50.000) con el techo subiendo a 80.000 → conserva sus 12.000.
- **Techo bajando** (120.000/200.000 → techo 50.000) → clampado a 50.000/50.000, `current_hp ≤ total_hp`. Sin el `LEAST` este caso daba barra >100%.
- Boss `defeated` no se toca; el vivo de al lado sí escala.

Más **5 tests unitarios** nuevos (`backend/tests/boss-hp-scaling.test.mjs`) sobre `bossHpForActiveUsers`: suelo, punto de cruce exacto en 125 activos, escalado lineal por encima, monotonía, resultado entero (la columna es `integer`) y entradas basura (`null`, `NaN`, negativos, strings) que nunca bajan del suelo. `npm test`: **17 pasan, 0 fallan** (2 skips preexistentes por falta de `DATABASE_URL`).

`node --check` OK. Sin cambios de frontend. No se tocó producción ni la BD real.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNEe7PaSrajFNupFZFSqL1)_