### PR TITLE
security(auth): revocación de JWT vía `users.token_version` + `is_admin` desde la BD

### DIFF
--- a/backend/admin.js
+++ b/backend/admin.js
@@ -271,6 +271,30 @@ router.get('/analytics', authenticate, isAdmin, async (req, res) => {
   }
 });
 
+// Revoke every live session of a user: sube `users.token_version`, que el
+// middleware compara contra el claim `tv` del token. Es la palanca de la
+// revocación de JWT — sin esto la columna no sirve de nada. Úsalo para logout
+// global, al banear, o al quitarle admin a alguien (el rol ya se lee de la BD,
+// pero esto además le tira la sesión).
+router.post('/revoke-sessions', authenticate, isAdmin, async (req, res) => {
+  const { user_id } = req.body;
+  if (!user_id) return res.status(400).json({ message: 'user_id required' });
+  try {
+    const result = await query(
+      'UPDATE users SET token_version = COALESCE(token_version, 0) + 1 WHERE id = $1 RETURNING id, token_version',
+      [user_id]
+    );
+    if (result.rowCount === 0) return res.status(404).json({ message: 'User not found' });
+    res.json({
+      message: `Sesiones revocadas para ${result.rows[0].id}`,
+      token_version: result.rows[0].token_version,
+    });
+  } catch (error) {
+    console.error('Error revoking sessions:', error);
+    res.status(500).json({ message: 'Error revoking sessions' });
+  }
+});
+
 // Give an item to a user by name — creates it if it doesn't exist yet
 router.post('/give-item', authenticate, isAdmin, async (req, res) => {
   const { user_id, item_name } = req.body;

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -10,8 +10,21 @@ import { loginLimiter, signupLimiter, oauthLimiter } from './utils/rateLimiters.
 const router = express.Router();
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
-const generateToken = (userId, isAdmin) => {
-  return jwt.sign({ id: userId, is_admin: isAdmin }, process.env.JWT_SECRET, { expiresIn: '30d' });
+// El TTL sigue siendo de 30 días; la revocación la da `token_version` (claim `tv`),
+// que el middleware compara contra `users.token_version` en cada petición: subirla
+// invalida de golpe todos los tokens vivos de ese usuario.
+//
+// `token_version` se lee aquí y no se pide al llamante a propósito: los tres sitios
+// que emiten token traen el `user` de SELECTs distintos, y que uno se dejara la
+// columna produciría silenciosamente tokens con `tv: 0` — es decir, tokens que
+// sobreviven a una revocación. Es una query extra sólo en el login.
+//
+// `is_admin` sigue en el payload por compatibilidad con lo que ya lo lee, pero YA NO
+// es la fuente de verdad: el middleware lo sobrescribe con el valor de la BD.
+const generateToken = async (userId, isAdmin) => {
+  const res = await query('SELECT token_version FROM users WHERE id = $1', [userId]);
+  const tv = Number(res.rows[0]?.token_version) || 0;
+  return jwt.sign({ id: userId, is_admin: isAdmin, tv }, process.env.JWT_SECRET, { expiresIn: '30d' });
 };
 
 const generateReferralCode = () => {
@@ -70,7 +83,7 @@ router.post('/google', oauthLimiter, async (req, res) => {
       ensureUsername(user.id, user.name).catch(() => {});
     }
 
-    const sessionToken = generateToken(user.id, user.is_admin);
+    const sessionToken = await generateToken(user.id, user.is_admin);
 
     // Get read blogs list
     const readBlogsRes = await query(
@@ -126,7 +139,7 @@ router.post('/signup', signupLimiter, async (req, res) => {
     const user = result.rows[0];
     await applyReferral(user.id, incomingRef);
     ensureUsername(user.id, user.name).catch(() => {});
-    const token = generateToken(user.id, user.is_admin);
+    const token = await generateToken(user.id, user.is_admin);
 
     res.json({
       token,
@@ -171,7 +184,7 @@ router.post('/login', loginLimiter, async (req, res) => {
       return res.status(401).json({ code: 'ERR_WRONG_PASSWORD', message: 'Incorrect password' });
     }
 
-    const token = generateToken(user.id, user.is_admin);
+    const token = await generateToken(user.id, user.is_admin);
 
     // Get read blogs list
     const readBlogsRes = await query(

--- a/backend/index.js
+++ b/backend/index.js
@@ -464,6 +464,7 @@ apiRouter.get('/db/init', async (req, res) => {
           UNIQUE(user_id, post_slug)
       )`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE`,
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER DEFAULT 0`,
       // Admin grant is intentionally NOT performed here. Bootstrap an admin with
       // `node backend/scripts/grant_admin.js <email>` instead of via HTTP.
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS daily_boss_damage INTEGER DEFAULT 0`,
@@ -759,6 +760,9 @@ async function ensureSchemaMigrations() {
     await query('ALTER TABLE exercises ADD COLUMN IF NOT EXISTS primary_muscle_group VARCHAR(50)');
     // Referral-invite push is sent at most once per user (see referralReminders.js).
     await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_reminder_sent BOOLEAN DEFAULT FALSE');
+    // Revocación de JWT: subir `token_version` invalida todos los tokens vivos de
+    // ese usuario (logout global, ban, cambio de rol). Lo compara middleware.js.
+    await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER DEFAULT 0');
     // Per-user "feature seen" flags that drive the NEW badges/dots.
     await query(`CREATE TABLE IF NOT EXISTS user_feature_seen (
         user_id     VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/middleware.js
+++ b/backend/middleware.js
@@ -1,6 +1,45 @@
 import jwt from 'jsonwebtoken';
+import { query } from './db.js';
 
-export const authenticate = (req, res, next) => {
+/**
+ * Resuelve el estado ACTUAL del usuario del token contra la BD.
+ *
+ * Los tokens duran 30 días y no había forma de revocarlos: quitarle admin a
+ * alguien no surtía efecto hasta que caducase su token, porque `is_admin` se leía
+ * del claim firmado. Esta única lectura por PK arregla las dos cosas a la vez:
+ *
+ *  - `token_version`: subirla en `users` invalida TODOS los tokens de ese usuario
+ *    (logout global, ban, cambio de rol) sin flujo de refresh ni tocar el frontend.
+ *  - `is_admin` sale de la BD, no del claim, así que un cambio de rol es inmediato.
+ *
+ * @returns {Promise<{ok: true, user: object} | {ok: false, status: number, message: string}>}
+ */
+async function resolveTokenUser(decoded) {
+  let row;
+  try {
+    const res = await query('SELECT id, is_admin, token_version FROM users WHERE id = $1', [decoded.id]);
+    row = res.rows[0];
+  } catch (err) {
+    // Fallar cerrado: sin poder comprobar la revocación no se concede acceso.
+    console.error('[auth] No se pudo verificar el token contra la BD:', err.message);
+    return { ok: false, status: 503, message: 'Auth temporarily unavailable.' };
+  }
+
+  // Usuario borrado: su token no debe seguir valiendo.
+  if (!row) return { ok: false, status: 401, message: 'Invalid token.' };
+
+  // Un token emitido antes del último bump queda invalidado. Los tokens ya en
+  // circulación (anteriores a esta columna) no llevan `tv`; cuentan como versión 0,
+  // que es el default de la columna, así que NO se invalida a nadie al desplegar.
+  const tokenVersion = Number(decoded.tv) || 0;
+  if (tokenVersion !== (Number(row.token_version) || 0)) {
+    return { ok: false, status: 401, message: 'Session expired. Please log in again.' };
+  }
+
+  return { ok: true, user: { ...decoded, id: row.id, is_admin: row.is_admin === true } };
+}
+
+export const authenticate = async (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -9,23 +48,30 @@ export const authenticate = (req, res, next) => {
 
   const token = authHeader.split(' ')[1];
 
+  let decoded;
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = decoded;
-    next();
+    decoded = jwt.verify(token, process.env.JWT_SECRET);
   } catch (error) {
-    res.status(401).json({ message: 'Invalid token.' });
+    return res.status(401).json({ message: 'Invalid token.' });
   }
+
+  const resolved = await resolveTokenUser(decoded);
+  if (!resolved.ok) return res.status(resolved.status).json({ message: resolved.message });
+
+  req.user = resolved.user;
+  next();
 };
 
 export const isAdmin = (req, res, next) => {
+  // `req.user.is_admin` viene de la BD (ver resolveTokenUser), no del claim firmado,
+  // así que quitarle admin a alguien surte efecto en su siguiente petición.
   if (!req.user || !req.user.is_admin) {
     return res.status(403).json({ message: 'Access denied. Admin privileges required.' });
   }
   next();
 };
 
-export const optionalAuthenticate = (req, res, next) => {
+export const optionalAuthenticate = async (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -34,12 +80,16 @@ export const optionalAuthenticate = (req, res, next) => {
 
   const token = authHeader.split(' ')[1];
 
+  let decoded;
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = decoded;
-    next();
+    decoded = jwt.verify(token, process.env.JWT_SECRET);
   } catch (error) {
-    // If token is invalid, just continue without user
-    next();
+    return next(); // token inválido → se sigue como anónimo
   }
+
+  const resolved = await resolveTokenUser(decoded);
+  // Token revocado o BD caída: se sigue como anónimo en vez de romper una ruta
+  // que de todas formas funciona sin sesión.
+  if (resolved.ok) req.user = resolved.user;
+  next();
 };

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -327,6 +327,13 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS skill_points INTEGER DEFAULT 0;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS skill_points_claimed INTEGER DEFAULT 1;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS skill_perks JSONB DEFAULT '{}'::jsonb;
 
+-- Revocación de JWT. Los tokens duran 30 días y no había forma de invalidarlos:
+-- subir `token_version` invalida de golpe TODOS los tokens vivos de ese usuario
+-- (logout global, ban, cambio de rol). El claim `tv` del token se compara contra
+-- esta columna en cada petición (backend/middleware.js). Default 0 = los tokens
+-- ya emitidos, que no llevan `tv`, siguen siendo válidos tras desplegar.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER DEFAULT 0;
+
 -- Referral System
 ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code VARCHAR(20) UNIQUE;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_by VARCHAR(255) REFERENCES users(id);


### PR DESCRIPTION
Implementa la opción **(B)** que elegiste el 2026-07-27 para la task de JWT (P3 — Deuda técnica). Se mantiene el TTL de 30 días y **no hace falta tocar el frontend**.

## El agujero

`middleware.js` leía `is_admin` **del claim firmado**. Con tokens de 30 días eso significaba que quitarle admin a alguien —o banearlo— no surtía efecto hasta un mes después. Y no había ninguna forma de invalidar un token.

## El fix

Una sola lectura por PK en el middleware arregla las dos cosas a la vez:

- **`users.token_version INTEGER DEFAULT 0`** + claim `tv` en el token. Subir la columna invalida **todos** los tokens vivos de ese usuario: logout global, ban, cambio de rol — sin flujo de refresh.
- **`is_admin` sale de la BD**, no del claim. Sigue en el payload por compatibilidad con lo que ya lo lee, pero el middleware lo sobrescribe.

**Al desplegar no se cae la sesión de nadie**: los tokens ya emitidos no llevan `tv`, se cuentan como versión 0, que es justo el default de la columna.

Extras que el cambio arrastra:
- Un token de un usuario **borrado** deja de valer (antes seguía pasando).
- Si la BD falla, `authenticate` **falla cerrado** (503) en vez de conceder acceso sin poder comprobar la revocación; `optionalAuthenticate` degrada a anónimo para no tumbar rutas públicas.

### Dos decisiones que tomé y quiero que veas

1. **`POST /admin/revoke-sessions`** (nuevo, `authenticate + isAdmin`). No estaba en la decisión, pero sin una palanca que suba la columna la revocación es inerte y tendrías que entrar por `psql`. Son 15 líneas; si prefieres no exponerlo, se quita.
2. **`generateToken` lee `token_version` él mismo** en vez de fiarse del `user` que le pase cada llamante. Los tres sitios que emiten token (`/google`, `/signup`, `/login`) traen el `user` de SELECTs distintos, y que uno se dejara la columna produciría silenciosamente tokens con `tv: 0` — o sea, tokens que **sobreviven a una revocación**. Es una query extra sólo en el login.

### Sobre `is_banned`

Tu decisión mencionaba leer también `is_banned` de la BD. **Esa columna no existe** en ningún sitio del backend (`schema.sql`, `/db/init`, ni ningún `ALTER`) — no hay sistema de baneos que conectar, así que no me lo he inventado. `token_version` te da igualmente la palanca: el día que lo añadas, banear = subir la versión y la sesión cae al instante.

### Coste

Una lectura indexada por PK a `users` en cada petición autenticada. La mayoría de handlers ya consultan `users` de todas formas.

## Verificación: **integración local** (backend real arrancado)

Postgres 16 efímero + `schema.sql`, backend arrancado con `DATABASE_URL` y `JWT_SECRET` dummy, todo por `curl` contra la API real:

| | Resultado |
|---|---|
| Signup emite token con `tv: 0`; ruta autenticada | 200 |
| Subir `token_version` en BD → mismo token | **401** "Session expired" |
| Re-login → token nuevo con `tv: 1` | 200 |
| Token viejo tras el re-login | sigue **401** (no revive) |
| `is_admin = TRUE` en BD → ruta admin | 200 |
| **`is_admin = FALSE` en BD, mismo token → ruta admin** | **403 al instante** ← el fix |
| `POST /admin/revoke-sessions` | 200, `token_version: 2`, y su propio token pasa a 401 |
| …con `user_id` inexistente / sin `user_id` | 404 / 400 |
| Token de usuario **borrado** | 401 |
| Token revocado en ruta con `optionalAuthenticate` (`/blog`) | **200** — degrada a anónimo, no rompe |
| Firma inválida | 401 |

La columna se añade en las **tres** fuentes de esquema (`schema.sql`, `ensureSchemaMigrations()` de arranque y `/db/init`) para no ampliar el drift que ya trackea la task de unificación. `node --check` OK en los 5 ficheros. Sin cambios de frontend. No se tocó producción ni la BD real.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNEe7PaSrajFNupFZFSqL1)_