### PR TITLE
refactor(schema): `schema.sql` como fuente única, aplicada en el arranque

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readFile } from 'fs/promises';
 
 // 1. Initialize environment variables first (works from repo root and backend cwd)
 const __filename = fileURLToPath(import.meta.url);
@@ -476,27 +477,16 @@ apiRouter.get('/db/init', async (req, res) => {
       `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS boss_gif TEXT`,
       `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS boss_damaged TEXT`,
       `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS order_index INTEGER DEFAULT 0`,
-      `ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS is_seasonal BOOLEAN DEFAULT FALSE`,
+      // Sólo SEEDS. El DDL vive en schema.sql, que se aplica en el arranque
+      // (ensureSchemaMigrations). Antes estaba duplicado aquí y divergía.
+      // NOTA: para dar admin, ejecutar fuera de banda `node backend/scripts/grant_admin.js <email>`.
+      // No es SQL, así que NO puede ir en este array: el loop de abajo se lo pasaría
+      // a query() y reventaría /db/init entero.
       `UPDATE cosmetics SET is_seasonal = TRUE WHERE name IN ('Aura de Pascua', 'Rabbit Slayer', 'Easter Celebration')`,
-      `ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS rarity VARCHAR(50) DEFAULT 'common'`,
       `UPDATE cosmetics SET rarity = 'legendary' WHERE price >= 1200`,
-      `UPDATE cosmetics SET rarity = 'epic' WHERE price < 1200 AND price >= 600`,
+      `UPDATE cosmetics SET rarity = 'especial' WHERE price < 1200 AND price >= 600`,
       `UPDATE cosmetics SET rarity = 'rare' WHERE price < 600 AND price >= 200`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_spin_at TIMESTAMP WITH TIME ZONE`,
-      // Daily Roulette cooldown (24h wheel), separate from the 4h last_spin_at.
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_daily_spin_at TIMESTAMP WITH TIME ZONE`,
-      // Temporary per-stat consumable buffs: { "str": { "value": 3, "expiry": "<iso>" }, ... }
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS stat_buffs JSONB DEFAULT '{}'::jsonb`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS has_seen_avatar_overhaul BOOLEAN DEFAULT FALSE`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_streak_reward_date DATE`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS push_disabled BOOLEAN DEFAULT FALSE`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_jackpot_week TEXT`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS username VARCHAR(50)`,
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users(username) WHERE username IS NOT NULL`,
-      // Mark old bosses as inactive to avoid overlapping
       `UPDATE boss_fights SET status = 'defeated' WHERE order_index = 0 AND status = 'active'`,
-      
-      // Boss Backlog
       `INSERT INTO boss_fights (name, description, total_hp, current_hp, start_date, end_date, status, image_url, order_index) 
        SELECT 'Artorias the Abysswalker', 'Se saltó tantos "días de pierna" que acabó caminando por el abismo. Su brazo izquierdo está roto de intentar muscle-ups sin calentar.', GREATEST(10000, (SELECT COUNT(*) * 25 FROM users)), GREATEST(10000, (SELECT COUNT(*) * 25 FROM users)), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '100 years', 'active', 'https://static.wikia.nocookie.net/darksouls/images/4/45/Artorias_the_Abysswalker_Render.png', 1
        WHERE NOT EXISTS (SELECT 1 FROM boss_fights WHERE name = 'Artorias the Abysswalker')`,
@@ -527,8 +517,6 @@ apiRouter.get('/db/init', async (req, res) => {
       `INSERT INTO boss_fights (name, description, total_hp, current_hp, start_date, end_date, status, image_url, order_index) 
        SELECT 'The Nameless King', 'Perdió su nombre en una apuesta sobre quién aguantaba más en plancha isométrica sobre un dragón de tormenta.', GREATEST(10000, (SELECT COUNT(*) * 25 FROM users)), GREATEST(10000, (SELECT COUNT(*) * 25 FROM users)), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '100 years', 'active', 'https://static.wikia.nocookie.net/darksouls/images/d/d4/The_Nameless_King_Render.png', 10
        WHERE NOT EXISTS (SELECT 1 FROM boss_fights WHERE name = 'The Nameless King')`,
-      
-      // Update descriptions in case they already exist
       `UPDATE boss_fights SET description = 'Se saltó tantos "días de pierna" que acabó caminando por el abismo. Su brazo izquierdo está roto de intentar muscle-ups sin calentar.' WHERE name = 'Artorias the Abysswalker'`,
       `UPDATE boss_fights SET description = 'Soberana del Fin y de las dominadas con lastre. Si no haces el rango completo, te lanza un aliento que huele a batido de proteínas caducado.' WHERE name = 'The Ender Dragon'`,
       `UPDATE boss_fights SET description = 'El Rey de los Cielos... y de las dominadas explosivas. Vuela porque no aguanta el peso de su propio ego en la barra.' WHERE name = 'Rathalos'`,
@@ -539,17 +527,12 @@ apiRouter.get('/db/init', async (req, res) => {
       `UPDATE boss_fights SET description = 'La maldad pura que asoló Hyrule porque alguien usó su rack de potencia para hacer curls de bíceps.' WHERE name = 'Calamity Ganon'`,
       `UPDATE boss_fights SET description = 'Viene a contar tus repeticiones en el gimnasio del infierno. Si no tocas la barbilla en la barra, tu serie no cuenta para el ranking.' WHERE name = 'Diablo'`,
       `UPDATE boss_fights SET description = 'Perdió su nombre en una apuesta sobre quién aguantaba más en plancha isométrica sobre un dragón de tormenta.' WHERE name = 'The Nameless King'`,
-      
-      // CS2 Titles
       `INSERT INTO cosmetics (name, description, type, price, css_value) 
        SELECT 'Plata 2', 'El inicio de un largo camino. Al menos no estás en Plata 1.', 'title', 150, 'color: #a0a0a0; font-weight: bold;'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Plata 2')`,
       `INSERT INTO cosmetics (name, description, type, price, css_value) 
        SELECT 'Nova de Oro 4', 'Ya empiezas a entender cómo funciona esto. Un rango con prestigio.', 'title', 450, 'color: #ffd700; font-weight: bold; text-shadow: 0 0 5px rgba(255,215,0,0.5);'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Nova de Oro 4')`,
-      
-      // SEASONAL LEGENDARY SETS
-      // 1. Void Mana
       `INSERT INTO cosmetics (name, description, type, price, css_value, is_seasonal, rarity) 
        SELECT 'Arcane Master', 'Portador del flujo eterno del mana.', 'title', 2500, 'title-mana', true, 'legendary'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Arcane Master')`,
@@ -559,8 +542,6 @@ apiRouter.get('/db/init', async (req, res) => {
       `INSERT INTO cosmetics (name, description, type, price, css_value, is_seasonal, rarity) 
        SELECT 'Abyssal Portal', 'Un vistazo al abismo infinito.', 'background', 2500, 'bg-mana', true, 'legendary'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Abyssal Portal')`,
-
-      // 2. Infernal Soul
       `INSERT INTO cosmetics (name, description, type, price, css_value, is_seasonal, rarity) 
        SELECT 'Dragonborn', 'Sangre de dragón corre por tus venas.', 'title', 2500, 'title-lava', true, 'legendary'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Dragonborn')`,
@@ -570,8 +551,6 @@ apiRouter.get('/db/init', async (req, res) => {
       `INSERT INTO cosmetics (name, description, type, price, css_value, is_seasonal, rarity) 
        SELECT 'Inferno', 'El mundo arde a tu alrededor.', 'background', 2500, 'bg-lava', true, 'legendary'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Inferno')`,
-
-      // 3. Chronos Glitch
       `INSERT INTO cosmetics (name, description, type, price, css_value, is_seasonal, rarity) 
        SELECT 'Synthetix', 'Tu realidad se está fragmentando.', 'title', 2500, 'title-glitch', true, 'legendary'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Synthetix')`,
@@ -581,77 +560,6 @@ apiRouter.get('/db/init', async (req, res) => {
       `INSERT INTO cosmetics (name, description, type, price, css_value, is_seasonal, rarity) 
        SELECT 'Digital Storm', 'Tormenta de datos encriptados.', 'background', 2500, 'bg-glitch', true, 'legendary'
        WHERE NOT EXISTS (SELECT 1 FROM cosmetics WHERE name = 'Digital Storm')`,
-      
-      `CREATE TABLE IF NOT EXISTS daily_summaries (
-          id SERIAL PRIMARY KEY,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          date DATE NOT NULL DEFAULT CURRENT_DATE,
-          title VARCHAR(255),
-          description TEXT,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id, date)
-      )`,
-      `CREATE TABLE IF NOT EXISTS streak_freezes (
-          id SERIAL PRIMARY KEY,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          freeze_date DATE NOT NULL,
-          spent_coins INTEGER NOT NULL DEFAULT 250,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id, freeze_date)
-      )`,
-      `CREATE INDEX IF NOT EXISTS idx_streak_freezes_user_date ON streak_freezes(user_id, freeze_date)`,
-      `CREATE TABLE IF NOT EXISTS summary_interactions (
-          id SERIAL PRIMARY KEY,
-          summary_id INTEGER REFERENCES daily_summaries(id) ON DELETE CASCADE,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          type VARCHAR(50) NOT NULL,
-          content TEXT,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-      )`,
-      `CREATE TABLE IF NOT EXISTS boss_kill_posts (
-          id SERIAL PRIMARY KEY,
-          boss_fight_id INTEGER REFERENCES boss_fights(id) ON DELETE CASCADE,
-          boss_name VARCHAR(255),
-          boss_image TEXT,
-          killer_user_id VARCHAR(255) REFERENCES users(id) ON DELETE SET NULL,
-          killer_name VARCHAR(255),
-          top3 JSONB DEFAULT '[]',
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(boss_fight_id)
-      )`,
-      `CREATE INDEX IF NOT EXISTS idx_boss_kill_posts_created ON boss_kill_posts(created_at DESC)`,
-      // Hot status/interaction scans (issue #265).
-      `CREATE INDEX IF NOT EXISTS idx_summary_interactions_summary_type ON summary_interactions(summary_id, type)`,
-      `CREATE INDEX IF NOT EXISTS idx_pvp_fights_status ON pvp_fights(status)`,
-      `CREATE INDEX IF NOT EXISTS idx_async_challenges_status ON async_challenges(status)`,
-      `CREATE INDEX IF NOT EXISTS idx_reps_user_date ON reps(user_id, date)`,
-      `CREATE INDEX IF NOT EXISTS idx_summaries_user_date ON daily_summaries(user_id, date)`,
-      `CREATE INDEX IF NOT EXISTS idx_friendships_users ON friendships(user_id_1, user_id_2)`,
-      `CREATE INDEX IF NOT EXISTS idx_inventory_user ON user_inventory(user_id)`,
-      `CREATE INDEX IF NOT EXISTS idx_users_total_reps ON users(total_reps DESC) WHERE is_private = false`,
-      `CREATE TABLE IF NOT EXISTS notifications (
-        id SERIAL PRIMARY KEY,
-        user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-        type VARCHAR(50) NOT NULL,
-        actor_id VARCHAR(255) REFERENCES users(id) ON DELETE SET NULL,
-        content TEXT,
-        target_id VARCHAR(255),
-        target_user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-        is_read BOOLEAN DEFAULT FALSE,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      )`,
-      // Va DESPUÉS de crear la tabla: este array se ejecuta en orden y un fallo
-      // aborta el resto de /db/init, así que un índice por delante de su tabla
-      // reventaría la inicialización de una BD limpia.
-      `CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at DESC)`,
-      // Per-user "feature seen" flags (NEW badges/dots)
-      `CREATE TABLE IF NOT EXISTS user_feature_seen (
-        user_id     VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-        feature_key VARCHAR(64) NOT NULL,
-        seen_at     TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        PRIMARY KEY (user_id, feature_key)
-      )`,
-      // Post Backgrounds Sync
       `INSERT INTO items (name, description, type, price, css_value, rarity) 
        VALUES ('Carbon Scan', 'Textura de carbono oscuro con línea de escaneo láser.', 'post_background', 1111, 'post-bg-carbon', 'rare')
        ON CONFLICT (name) DO UPDATE SET rarity = EXCLUDED.rarity`,
@@ -670,8 +578,6 @@ apiRouter.get('/db/init', async (req, res) => {
       `INSERT INTO items (name, description, type, price, css_value, rarity) 
        VALUES ('Calisthenics Legend', 'El rango máximo de la disciplina pura.', 'title', 9999, 'title-calistenico', 'calistenico')
        ON CONFLICT (name) DO UPDATE SET rarity = EXCLUDED.rarity`,
-       
-      // RPG ITEMS SEEDING (One per rarity)
       `INSERT INTO items (name, description, type, rarity, stats) 
        VALUES ('Harrapos de Entrenamiento', 'Ropa vieja pero funcional para empezar.', 'armor', 'common', '{"end": 1}')
        ON CONFLICT (name) DO UPDATE SET rarity = EXCLUDED.rarity, stats = EXCLUDED.stats`,
@@ -687,18 +593,6 @@ apiRouter.get('/db/init', async (req, res) => {
       `INSERT INTO items (name, description, type, rarity, stats)
        VALUES ('Armadura del Dios Calisténico', 'La culminación del entrenamiento físico.', 'armor', 'calistenico', '{"str": 20, "end": 20, "vig": 20}')
        ON CONFLICT (name) DO UPDATE SET rarity = EXCLUDED.rarity, stats = EXCLUDED.stats`,
-
-      // Referral system
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code VARCHAR(20)`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_by VARCHAR(255) REFERENCES users(id)`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_reward_given BOOLEAN DEFAULT FALSE`,
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_referral_code ON users(referral_code) WHERE referral_code IS NOT NULL`,
-      `CREATE INDEX IF NOT EXISTS idx_users_referred_by ON users(referred_by)`,
-
-      // Custom (user-created) training plans: NULL owner = predefined/global plan
-      `ALTER TABLE training_plans ADD COLUMN IF NOT EXISTS owner_user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE`,
-      `ALTER TABLE training_plans ADD COLUMN IF NOT EXISTS is_custom BOOLEAN DEFAULT FALSE`,
-      `CREATE INDEX IF NOT EXISTS idx_training_plans_owner ON training_plans(owner_user_id)`
     ];
     
     for (const q of queries) {
@@ -746,57 +640,26 @@ async function ensureAllTrainingExercisesExist() {
   }
 }
 
-// Lightweight, idempotent schema migrations run on every startup. Unlike the
-// heavy /db/init endpoint, this only ensures columns that newer code depends on
-// exist, so the app never queries a column that isn't there yet.
+// Aplica `schema.sql` en cada arranque. Es la ÚNICA fuente de verdad del
+// esquema (auditoría 2026-07, opción A): antes el esquema vivía repartido en
+// cuatro sitios —este arranque, el DDL de `GET /db/init`, `schema.sql` y
+// `ensureProfileSchema()` en profile.js— y el drift estaba garantizado.
+//
+// El fichero es idempotente de principio a fin (`CREATE TABLE IF NOT EXISTS`,
+// `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), así que re-aplicarlo
+// en cada boot no cambia nada en una BD ya migrada. Va en una sola llamada sin
+// parámetros a propósito: `pg` usa entonces el protocolo simple, que admite
+// varias sentencias, y así se respeta el orden de dependencias del fichero.
 async function ensureSchemaMigrations() {
   try {
-    await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS last_daily_spin_at TIMESTAMP WITH TIME ZONE');
-    // Grupo muscular del ejercicio (PR #336, combate ejercicio→daño). Lo lee el
-    // SELECT de POST /reps y el de training.js, pero solo estaba declarado en
-    // schema.sql, que NO se aplica en arranque: al desplegar #336 sin haber
-    // corrido schema.sql a mano, cada POST /reps moria con "column
-    // primary_muscle_group does not exist" y la app no dejaba registrar reps.
-    await query('ALTER TABLE exercises ADD COLUMN IF NOT EXISTS primary_muscle_group VARCHAR(50)');
-    // Referral-invite push is sent at most once per user (see referralReminders.js).
-    await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_reminder_sent BOOLEAN DEFAULT FALSE');
-    // Revocación de JWT: subir `token_version` invalida todos los tokens vivos de
-    // ese usuario (logout global, ban, cambio de rol). Lo compara middleware.js.
-    await query('ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER DEFAULT 0');
-    // Cosméticos exclusivos (títulos de prestigio): no se compran, no se venden y
-    // no pueden salir de un cofre — solo se otorgan al prestigiar. Lo consultan la
-    // tienda, la rotación diaria y TODAS las queries de loot por rareza.
-    await query('ALTER TABLE items ADD COLUMN IF NOT EXISTS is_exclusive BOOLEAN DEFAULT FALSE');
-    // Per-user "feature seen" flags that drive the NEW badges/dots.
-    await query(`CREATE TABLE IF NOT EXISTS user_feature_seen (
-        user_id     VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-        feature_key VARCHAR(64) NOT NULL,
-        seen_at     TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        PRIMARY KEY (user_id, feature_key)
-    )`);
-    // Indexes for hot status/interaction scans (issue #265).
-    await query("CREATE INDEX IF NOT EXISTS idx_summary_interactions_summary_type ON summary_interactions(summary_id, type)");
-    await query("CREATE INDEX IF NOT EXISTS idx_pvp_fights_status ON pvp_fights(status)");
-    await query("CREATE INDEX IF NOT EXISTS idx_async_challenges_status ON async_challenges(status)");
-    // Índices calientes que faltaban. Se aplican uno a uno: `notifications` solo
-    // se crea en /db/init (no está en schema.sql), así que si la tabla no existe
-    // todavía no debe impedir que se cree el resto.
-    for (const [label, sql] of [
-      // El centro de notificaciones pagina por usuario y fecha en cada poll; sin
-      // este índice era seq scan + sort de toda la tabla (que crece sin cota).
-      ['notifications(user_id, created_at)', "CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at DESC)"],
-      // Ranking global: subqueries correlacionadas por cada fila del feed social.
-      ['users(total_reps)', "CREATE INDEX IF NOT EXISTS idx_users_total_reps ON users(total_reps DESC) WHERE is_private = false"],
-    ]) {
-      try {
-        await query(sql);
-      } catch (indexErr) {
-        console.error(`[Startup migration] Índice ${label} no aplicado:`, indexErr.message);
-      }
-    }
-    console.log('[Startup migration] Schema migrations applied.');
+    const schemaPath = path.join(__dirname, 'schema.sql');
+    const sql = await readFile(schemaPath, 'utf8');
+    await query(sql);
+    console.log('[Startup migration] schema.sql aplicado.');
   } catch (err) {
-    console.error('[Startup migration] Failed to apply schema migrations:', err);
+    // No se tumba el proceso: una BD ya migrada funciona igual, y caerse aquí
+    // dejaría la app entera abajo por un fallo de migración.
+    console.error('[Startup migration] Failed to apply schema.sql:', err);
   }
 }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -387,101 +387,10 @@ apiRouter.get('/db/init', async (req, res) => {
   }
   try {
     const queries = [
-      `CREATE TABLE IF NOT EXISTS users (
-          id VARCHAR(255) PRIMARY KEY,
-          name VARCHAR(255) NOT NULL,
-          email VARCHAR(255) UNIQUE NOT NULL,
-          password_hash VARCHAR(255),
-          avatar_url TEXT,
-          total_reps INTEGER DEFAULT 0,
-          is_private BOOLEAN DEFAULT FALSE,
-          daily_goal INTEGER DEFAULT 50,
-          body_weight DECIMAL DEFAULT 75.0,
-          last_streak_reward_date DATE,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-      )`,
-      `CREATE TABLE IF NOT EXISTS reps (
-          id SERIAL PRIMARY KEY,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          count INTEGER NOT NULL DEFAULT 0,
-          date DATE NOT NULL DEFAULT CURRENT_DATE,
-          exercise_type VARCHAR(50) DEFAULT 'pullups',
-          added_weight DECIMAL DEFAULT 0.0,
-          boss_damage_dealt INTEGER DEFAULT 0,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id, date, exercise_type)
-      )`,
-      `ALTER TABLE reps ADD COLUMN IF NOT EXISTS boss_damage_dealt INTEGER DEFAULT 0`,
-      `ALTER TABLE reps ADD COLUMN IF NOT EXISTS active_multiplier DECIMAL DEFAULT 1.0`,
-      `CREATE TABLE IF NOT EXISTS cosmetics (
-          id SERIAL PRIMARY KEY,
-          name VARCHAR(255) UNIQUE NOT NULL,
-          description TEXT,
-          type VARCHAR(50) NOT NULL,
-          price INTEGER NOT NULL,
-          css_value TEXT,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-      )`,
-      `CREATE TABLE IF NOT EXISTS user_inventory (
-          id SERIAL PRIMARY KEY,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          cosmetic_id INTEGER REFERENCES cosmetics(id) ON DELETE CASCADE,
-          is_new BOOLEAN DEFAULT TRUE,
-          acquired_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id, cosmetic_id)
-      )`,
-      `ALTER TABLE user_inventory ADD COLUMN IF NOT EXISTS is_new BOOLEAN DEFAULT TRUE`,
-      `CREATE TABLE IF NOT EXISTS boss_fights (
-          id SERIAL PRIMARY KEY,
-          name VARCHAR(255) NOT NULL,
-          description TEXT,
-          total_hp INTEGER NOT NULL,
-          current_hp INTEGER NOT NULL,
-          start_date TIMESTAMP WITH TIME ZONE NOT NULL,
-          end_date TIMESTAMP WITH TIME ZONE NOT NULL,
-          status VARCHAR(50) DEFAULT 'active'
-      )`,
-      `CREATE TABLE IF NOT EXISTS event_participants (
-          id SERIAL PRIMARY KEY,
-          boss_fight_id INTEGER REFERENCES boss_fights(id) ON DELETE CASCADE,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          damage_dealt INTEGER DEFAULT 0,
-          chests_claimed INTEGER DEFAULT 0,
-          UNIQUE(boss_fight_id, user_id)
-      )`,
-      `CREATE TABLE IF NOT EXISTS friendships (
-          id SERIAL PRIMARY KEY,
-          user_id_1 VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          user_id_2 VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          status VARCHAR(50) DEFAULT 'accepted',
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id_1, user_id_2)
-      )`,
-      `CREATE TABLE IF NOT EXISTS user_read_blogs (
-          id SERIAL PRIMARY KEY,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          post_slug VARCHAR(255) NOT NULL,
-          read_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id, post_slug)
-      )`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER DEFAULT 0`,
-      // Admin grant is intentionally NOT performed here. Bootstrap an admin with
-      // `node backend/scripts/grant_admin.js <email>` instead of via HTTP.
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS daily_boss_damage INTEGER DEFAULT 0`,
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_boss_damage_date DATE DEFAULT CURRENT_DATE`,
-      `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS image_url TEXT`,
-      // Animated boss clips, stored as *filenames* of locally-hosted videos
-      // (served from /public/video): boss_gif = idle loop, boss_damaged = hit
-      // reaction. Both optional; the UI falls back to image_url when missing.
-      `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS boss_gif TEXT`,
-      `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS boss_damaged TEXT`,
-      `ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS order_index INTEGER DEFAULT 0`,
       // Sólo SEEDS. El DDL vive en schema.sql, que se aplica en el arranque
       // (ensureSchemaMigrations). Antes estaba duplicado aquí y divergía.
-      // NOTA: para dar admin, ejecutar fuera de banda `node backend/scripts/grant_admin.js <email>`.
-      // No es SQL, así que NO puede ir en este array: el loop de abajo se lo pasaría
-      // a query() y reventaría /db/init entero.
+      // NOTA: para dar admin, ejecutar fuera de banda `node backend/scripts/grant_admin.js <email>`
+      // (NO es SQL; no debe ir en este array o el loop de abajo lo pasa a query() y revienta /db/init).
       `UPDATE cosmetics SET is_seasonal = TRUE WHERE name IN ('Aura de Pascua', 'Rabbit Slayer', 'Easter Celebration')`,
       `UPDATE cosmetics SET rarity = 'legendary' WHERE price >= 1200`,
       `UPDATE cosmetics SET rarity = 'especial' WHERE price < 1200 AND price >= 600`,

--- a/backend/profile.js
+++ b/backend/profile.js
@@ -5,96 +5,11 @@ import { optionalAuthenticate } from './middleware.js';
 
 const router = express.Router();
 
-let profileSchemaPromise = null;
-
-function ensureProfileSchema() {
-  if (!profileSchemaPromise) {
-    profileSchemaPromise = (async () => {
-      await query(`
-        CREATE TABLE IF NOT EXISTS items (
-          id SERIAL PRIMARY KEY,
-          name VARCHAR(255) NOT NULL,
-          description TEXT,
-          type VARCHAR(50) NOT NULL,
-          rarity VARCHAR(50) DEFAULT 'common',
-          stats JSONB DEFAULT '{}',
-          image_url TEXT,
-          css_value TEXT,
-          price INTEGER DEFAULT 0,
-          price_gems INTEGER DEFAULT 0,
-          svg_key TEXT,
-          is_seasonal BOOLEAN DEFAULT FALSE,
-          bundle_items TEXT,
-          original_price INTEGER,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(name)
-        )
-      `);
-
-      await query(`
-        ALTER TABLE items
-        ADD COLUMN IF NOT EXISTS price INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS price_gems INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS svg_key TEXT,
-        ADD COLUMN IF NOT EXISTS is_seasonal BOOLEAN DEFAULT FALSE,
-        ADD COLUMN IF NOT EXISTS bundle_items TEXT,
-        ADD COLUMN IF NOT EXISTS original_price INTEGER
-      `);
-
-      await query(`
-        ALTER TABLE users
-        ADD COLUMN IF NOT EXISTS reppy_coins INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS reppy_gems INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS daily_goal INTEGER DEFAULT 50,
-        ADD COLUMN IF NOT EXISTS str_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS dex_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS end_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS vig_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS int_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS fth_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS total_xp INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS body_weight DECIMAL DEFAULT 75.0,
-        ADD COLUMN IF NOT EXISTS is_private BOOLEAN DEFAULT FALSE,
-        ADD COLUMN IF NOT EXISTS current_level INTEGER DEFAULT 1,
-        ADD COLUMN IF NOT EXISTS level_chests_claimed INTEGER DEFAULT 1,
-        ADD COLUMN IF NOT EXISTS level_chests INTEGER DEFAULT 0,
-        ADD COLUMN IF NOT EXISTS damage_multiplier DECIMAL DEFAULT 1.0,
-        ADD COLUMN IF NOT EXISTS damage_multiplier_expiry TIMESTAMP WITH TIME ZONE,
-        ADD COLUMN IF NOT EXISTS stat_buffs JSONB DEFAULT '{}'::jsonb,
-        ADD COLUMN IF NOT EXISTS equipped_title_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_border_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_avatar_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_background_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_post_background_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_head_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_weapon_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_armor_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
-        ADD COLUMN IF NOT EXISTS equipped_boots_id INTEGER REFERENCES items(id) ON DELETE SET NULL
-      `);
-
-      await query(`
-        CREATE TABLE IF NOT EXISTS user_items (
-          id SERIAL PRIMARY KEY,
-          user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
-          item_id INTEGER REFERENCES items(id) ON DELETE CASCADE,
-          is_equipped BOOLEAN DEFAULT FALSE,
-          is_new BOOLEAN DEFAULT TRUE,
-          quantity INTEGER DEFAULT 1,
-          acquired_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-          UNIQUE(user_id, item_id)
-        )
-      `);
-
-      await query('ALTER TABLE user_items ADD COLUMN IF NOT EXISTS quantity INTEGER DEFAULT 1');
-      await query('ALTER TABLE user_items ADD COLUMN IF NOT EXISTS is_new BOOLEAN DEFAULT TRUE');
-    })().catch((error) => {
-      profileSchemaPromise = null;
-      throw error;
-    });
-  }
-
-  return profileSchemaPromise;
-}
+// El esquema de `items`/`user_items` y las columnas de `users` que esta ruta
+// necesita vivían aquí, creándose en la PRIMERA petición a /profile. Eso era
+// DDL en el hot path (locks de tabla por request) y una cuarta fuente de
+// esquema divergente. Todo eso está ahora en `schema.sql`, que se aplica al
+// arrancar el backend (auditoría 2026-07, opción A).
 
 // Top public users for SSG prerendering
 router.get('/top-public', async (req, res) => {
@@ -137,8 +52,6 @@ router.get('/:id', optionalAuthenticate, async (req, res) => {
   console.log(`[PROFILE_API] INCOMING - ID: ${rawId}, TYPE: ${type}`);
 
   try {
-    await ensureProfileSchema();
-
     // Try to find the user. If they have a 'user_' prefix or not, we want to be robust.
     let userResult = await query(`
         SELECT u.id, u.name, u.avatar_url, u.reppy_coins, u.reppy_gems, u.daily_goal,

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -556,3 +556,304 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS ui_style VARCHAR(20) DEFAULT 'operati
 -- que se compara con weakness_stat/resist_stat del enemigo. NULL para los
 -- ejercicios built-in de Reppy, que resuelven vía `stat_type`.
 ALTER TABLE exercises ADD COLUMN IF NOT EXISTS primary_muscle_group VARCHAR(50);
+
+-- =====================================================================
+-- Absorbido de las otras fuentes de esquema (auditoría 2026-07, opción A)
+-- =====================================================================
+-- Hasta ahora el esquema vivía repartido en CUATRO sitios: este fichero,
+-- el DDL de `GET /db/init`, `ensureSchemaMigrations()` y —el más sorprendente—
+-- `ensureProfileSchema()` en profile.js, que creaba `items` y `user_items`
+-- (las tablas de las que cuelga toda la economía) en la PRIMERA petición a
+-- /profile. Esto es lo que faltaba aquí; ahora `schema.sql` es la fuente única
+-- y el arranque lo aplica entero.
+
+-- Tienda / inventario. `equipped_*_id` de users referencia items(id), así que
+-- esta tabla tiene que existir antes que esas columnas.
+CREATE TABLE IF NOT EXISTS items (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    type VARCHAR(50) NOT NULL,
+    rarity VARCHAR(50) DEFAULT 'common', -- common | rare | especial | legendary | calistenico | cosmico
+    stats JSONB DEFAULT '{}',
+    image_url TEXT,
+    css_value TEXT,
+    price INTEGER DEFAULT 0,
+    price_gems INTEGER DEFAULT 0,
+    svg_key TEXT,
+    is_seasonal BOOLEAN DEFAULT FALSE,
+    bundle_items TEXT,
+    original_price INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(name)
+);
+ALTER TABLE items ADD COLUMN IF NOT EXISTS price INTEGER DEFAULT 0;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS price_gems INTEGER DEFAULT 0;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS svg_key TEXT;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS is_seasonal BOOLEAN DEFAULT FALSE;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS bundle_items TEXT;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS original_price INTEGER;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS is_customizable BOOLEAN DEFAULT FALSE;
+-- Cosméticos exclusivos (títulos de prestigio «Renacido I…V»): no se compran, no
+-- se venden y no pueden salir de un cofre — solo se otorgan al prestigiar. Lo
+-- consultan la tienda, la rotación diaria y TODAS las queries de loot por rareza.
+ALTER TABLE items ADD COLUMN IF NOT EXISTS is_exclusive BOOLEAN DEFAULT FALSE;
+
+CREATE TABLE IF NOT EXISTS user_items (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    item_id INTEGER REFERENCES items(id) ON DELETE CASCADE,
+    is_equipped BOOLEAN DEFAULT FALSE,
+    is_new BOOLEAN DEFAULT TRUE,
+    quantity INTEGER DEFAULT 1,
+    acquired_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, item_id)
+);
+
+-- Columnas de users que sólo declaraban /db/init o ensureProfileSchema.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS username VARCHAR(50);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS daily_boss_damage INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_boss_damage_date DATE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS total_xp INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS current_level INTEGER DEFAULT 1;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS level_chests_claimed INTEGER DEFAULT 1;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS level_chests INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS stat_buffs JSONB DEFAULT '{}'::jsonb;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_daily_spin_at TIMESTAMP WITH TIME ZONE;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username_unique ON users(LOWER(username)) WHERE username IS NOT NULL;
+
+-- Equipo y cosméticos equipados (FK a items, no a la tabla legacy `cosmetics`).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_title_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_border_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_avatar_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_background_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_post_background_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_head_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_weapon_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_armor_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS equipped_boots_id INTEGER REFERENCES items(id) ON DELETE SET NULL;
+
+-- Cosméticos legacy: columnas que sólo declaraba /db/init.
+ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS is_seasonal BOOLEAN DEFAULT FALSE;
+ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS rarity VARCHAR(50) DEFAULT 'common';
+
+-- Feed social: resumen diario + likes/comentarios.
+CREATE TABLE IF NOT EXISTS daily_summaries (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    date DATE NOT NULL DEFAULT CURRENT_DATE,
+    title VARCHAR(255),
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, date)
+);
+CREATE INDEX IF NOT EXISTS idx_summaries_user_date ON daily_summaries(user_id, date);
+
+CREATE TABLE IF NOT EXISTS summary_interactions (
+    id SERIAL PRIMARY KEY,
+    summary_id INTEGER REFERENCES daily_summaries(id) ON DELETE CASCADE,
+    user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    type VARCHAR(50) NOT NULL,
+    content TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_summary_interactions_summary_type ON summary_interactions(summary_id, type);
+
+CREATE TABLE IF NOT EXISTS boss_kill_posts (
+    id SERIAL PRIMARY KEY,
+    boss_fight_id INTEGER REFERENCES boss_fights(id) ON DELETE CASCADE,
+    boss_name VARCHAR(255),
+    boss_image TEXT,
+    killer_user_id VARCHAR(255) REFERENCES users(id) ON DELETE SET NULL,
+    killer_name VARCHAR(255),
+    top3 JSONB DEFAULT '[]',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(boss_fight_id)
+);
+CREATE INDEX IF NOT EXISTS idx_boss_kill_posts_created ON boss_kill_posts(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    type VARCHAR(50) NOT NULL,
+    actor_id VARCHAR(255) REFERENCES users(id) ON DELETE SET NULL,
+    content TEXT,
+    target_id VARCHAR(255),
+    target_user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    is_read BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at DESC);
+
+-- Boss comunitario: tiers que multiplican el HP (×8 legendario, ×3 épico).
+ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS is_legendary BOOLEAN DEFAULT FALSE;
+ALTER TABLE boss_fights ADD COLUMN IF NOT EXISTS is_epic BOOLEAN DEFAULT FALSE;
+
+-- Índices calientes (antes sólo en ensureSchemaMigrations o en scripts de archive/).
+CREATE INDEX IF NOT EXISTS idx_users_total_reps ON users(total_reps DESC) WHERE is_private = false;
+CREATE TABLE IF NOT EXISTS user_feature_seen (
+    user_id     VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    feature_key VARCHAR(64) NOT NULL,
+    seen_at     TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, feature_key)
+);
+
+-- --- PvP y retos asíncronos ---------------------------------------------
+-- Estas dos features vivas existían en producción SÓLO porque alguien ejecutó
+-- una vez `archive/migrate_pvp_tables.js` y `archive/apply_async_challenges_migration.js`;
+-- ninguna fuente canónica las declaraba. Absorbidas desde ahí.
+CREATE TABLE IF NOT EXISTS pvp_fights (
+    id SERIAL PRIMARY KEY,
+    challenger_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    challenged_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    status VARCHAR(50) DEFAULT 'pending',
+    hp1 INTEGER,
+    hp2 INTEGER,
+    max_hp INTEGER DEFAULT 5000,
+    time_limit INTEGER DEFAULT 60,
+    battlefield VARCHAR(50) DEFAULT 'default',
+    allowed_exercises JSONB DEFAULT '["pullups", "pushups", "dips"]'::jsonb,
+    winner_id VARCHAR(255) REFERENCES users(id),
+    damage1 INTEGER DEFAULT 0,
+    damage2 INTEGER DEFAULT 0,
+    anticheat_enabled BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP WITH TIME ZONE,
+    ended_at TIMESTAMP WITH TIME ZONE,
+    state JSONB DEFAULT '{}'::jsonb
+);
+ALTER TABLE pvp_fights ADD COLUMN IF NOT EXISTS state JSONB DEFAULT '{}'::jsonb;
+ALTER TABLE pvp_fights ADD COLUMN IF NOT EXISTS seed VARCHAR(64);
+CREATE INDEX IF NOT EXISTS idx_pvp_fights_active ON pvp_fights(status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_pvp_fights_status ON pvp_fights(status);
+
+CREATE TABLE IF NOT EXISTS pvp_events (
+    id SERIAL PRIMARY KEY,
+    fight_id INTEGER REFERENCES pvp_fights(id) ON DELETE CASCADE,
+    user_id VARCHAR(255) REFERENCES users(id) ON DELETE SET NULL,
+    type VARCHAR(50) NOT NULL,
+    payload JSONB,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_pvp_events_fight ON pvp_events(fight_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS async_challenges (
+    id SERIAL PRIMARY KEY,
+    challenger_id VARCHAR NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    challenged_id VARCHAR NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    goal_type VARCHAR(20) NOT NULL DEFAULT 'reps',
+    goal_value INT NOT NULL DEFAULT 100,
+    challenger_score INT NOT NULL DEFAULT 0,
+    challenged_score INT NOT NULL DEFAULT 0,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    winner_id VARCHAR REFERENCES users(id),
+    reward_coins INT NOT NULL DEFAULT 75,
+    reward_gems INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    resolved_at TIMESTAMPTZ,
+    CONSTRAINT no_self_challenge CHECK (challenger_id != challenged_id)
+);
+ALTER TABLE async_challenges ADD COLUMN IF NOT EXISTS reward_gems INT NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_async_challenges_challenger ON async_challenges(challenger_id);
+CREATE INDEX IF NOT EXISTS idx_async_challenges_challenged ON async_challenges(challenged_id);
+CREATE INDEX IF NOT EXISTS idx_async_challenges_status ON async_challenges(status);
+
+-- --- Columnas de `reps` que NINGUNA fuente declaraba ---------------------
+-- Sólo existían en producción por migraciones manuales. Sin ellas, `POST /reps`
+-- devuelve 500 en una BD recién creada (verificado en el test de arranque virgen).
+ALTER TABLE reps ADD COLUMN IF NOT EXISTS is_crit BOOLEAN DEFAULT FALSE;
+ALTER TABLE reps ADD COLUMN IF NOT EXISTS base_damage INTEGER DEFAULT 0;
+ALTER TABLE reps ADD COLUMN IF NOT EXISTS gear_bonus INTEGER DEFAULT 0;
+ALTER TABLE reps ADD COLUMN IF NOT EXISTS boss_fight_id INTEGER REFERENCES boss_fights(id) ON DELETE SET NULL;
+
+-- Columnas legacy de `cosmetics` que sólo aparecían en scripts sueltos.
+ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS price_gems INTEGER DEFAULT 0;
+ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS bundle_items TEXT;
+ALTER TABLE cosmetics ADD COLUMN IF NOT EXISTS original_price INTEGER;
+
+-- --- Columnas de `users` que sólo declaraban módulos sueltos o scripts ----
+-- Detectadas ejercitando la app contra una BD recién creada: sin ellas fallan
+-- POST /reps, /shop/daily, /missions y /roulette/status.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS buff_bonus INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS daily_refreshes INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_refresh_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_daily_missions_refill TIMESTAMP WITH TIME ZONE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS roulette_tickets_bought_today INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_roulette_ticket_bought_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_spin_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_jackpot_week TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS push_disabled BOOLEAN DEFAULT FALSE;
+-- Integración con Hevy (la API key va cifrada AES-256-GCM, ver utils/hevyCrypto.js).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS hevy_api_key TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS hevy_webhook_token TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS hevy_volume_kg BIGINT DEFAULT 0;
+
+-- --- Misiones e integración Hevy ----------------------------------------
+-- Absorbido de `archive/apply_missions_migration.js` y `archive/apply_hevy_migration.js`,
+-- que eran su única declaración (scripts de un solo uso que NO corren en runtime).
+CREATE TABLE IF NOT EXISTS missions (
+    id SERIAL PRIMARY KEY,
+    title_key VARCHAR(100) NOT NULL,
+    description_key VARCHAR(100),
+    goal_type VARCHAR(50) NOT NULL, -- 'reps' | 'streak' | 'damage'
+    goal_value INTEGER NOT NULL,
+    reward_xp INTEGER DEFAULT 0,
+    reward_gems INTEGER DEFAULT 0,
+    reward_coins INTEGER DEFAULT 0,
+    is_daily BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(title_key)
+);
+
+CREATE TABLE IF NOT EXISTS user_missions (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    mission_id INTEGER REFERENCES missions(id) ON DELETE CASCADE,
+    current_value INTEGER DEFAULT 0,
+    is_active BOOLEAN DEFAULT TRUE,
+    is_completed BOOLEAN DEFAULT FALSE,
+    is_claimed BOOLEAN DEFAULT FALSE,
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, mission_id)
+);
+ALTER TABLE user_missions ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT TRUE;
+CREATE INDEX IF NOT EXISTS idx_user_missions_user ON user_missions(user_id);
+
+CREATE TABLE IF NOT EXISTS hevy_exercise_map (
+    hevy_template_id    VARCHAR(64) PRIMARY KEY,
+    reppy_exercise_type VARCHAR(80) NOT NULL,
+    is_weighted         BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS hevy_imported_workouts (
+    hevy_workout_id VARCHAR(64) PRIMARY KEY,
+    user_id         VARCHAR(255) REFERENCES users(id) ON DELETE CASCADE,
+    imported_at     TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    workout_date    DATE,
+    volume_kg       BIGINT DEFAULT 0,
+    counts          JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_hevy_imported_user ON hevy_imported_workouts(user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_hevy_token ON users(hevy_webhook_token) WHERE hevy_webhook_token IS NOT NULL;
+
+-- `buff_bonus` va en `reps` (desglose del daño), no en `users`.
+ALTER TABLE reps ADD COLUMN IF NOT EXISTS buff_bonus INTEGER DEFAULT 0;
+
+-- =====================================================================
+-- PENDIENTE: tablas que NO se pueden reconstruir desde el repositorio
+-- =====================================================================
+-- Estas cuatro tablas existen en producción pero su `CREATE TABLE` no está en
+-- NINGÚN sitio del repo (ni aquí, ni en /db/init, ni en archive/, ni en scripts/).
+-- Se crearon a mano en algún momento y nunca se versionaron:
+--
+--   · daily_shop_items      (rotación diaria de la tienda — GET /shop/daily)
+--   · boss_participants     (daño por usuario en el boss comunitario)
+--   · weekly_challenges     (reto semanal)
+--   · user_skills           (árbol de habilidades)
+--
+-- Consecuencia: `schema.sql` todavía NO levanta una BD 100% funcional desde
+-- cero; `GET /shop/daily` falla en una base recién creada. Cerrar esto exige un
+-- `pg_dump --schema-only` de producción y pegar aquí su DDL — trabajo que encaja
+-- con la Fase 2/3 de la migración de BD, no con este PR.


### PR DESCRIPTION
Implementa la **opción (A)** que elegiste el 2026-07-27 para "Unificar las 3 fuentes de esquema" (P3 — Deuda técnica).

`ensureSchemaMigrations()` pasa a leer y aplicar **`schema.sql` entero** en cada arranque. El fichero es idempotente de principio a fin (`IF NOT EXISTS` en todo), así que re-aplicarlo no toca nada en una BD ya migrada. Va en una sola llamada sin parámetros a propósito: `pg` usa entonces el protocolo simple, que admite varias sentencias y respeta el orden de dependencias del fichero.

Retirado el DDL duplicado: **54 sentencias** fuera de `GET /db/init` (que queda sólo con sus 48 seeds) y `ensureProfileSchema()` eliminada de `profile.js`.

## ⚠️ Lo que encontré midiendo el drift — es peor de lo que decía la task

**Eran cuatro fuentes, no tres.** La cuarta es la que más me sorprendió: `ensureProfileSchema()` creaba **`items` y `user_items`** —las tablas de las que cuelga toda la economía— en la **primera petición a `/profile`**. DDL en el hot path y una fuente divergente más.

Y al ejercitar la app contra una BD virgen salió lo gordo: **7 tablas y ~17 columnas de features vivas no estaban declaradas en ninguna fuente canónica.** Existen en producción sólo porque alguien ejecutó una vez un script de `archive/` (que no corre en runtime):

| Sólo existían en `archive/` | |
|---|---|
| `pvp_fights`, `pvp_events` | `archive/migrate_pvp_tables.js` |
| `async_challenges` | `archive/apply_async_challenges_migration.js` |
| `missions`, `user_missions` | `archive/apply_missions_migration.js` |
| `hevy_exercise_map`, `hevy_imported_workouts` | `archive/apply_hevy_migration.js` |

Más `reps.is_crit / base_damage / gear_bonus / buff_bonus / boss_fight_id` y una docena de columnas de `users` (`buff_bonus`, `daily_refreshes`, `roulette_tickets_bought_today`, `hevy_api_key`, `push_disabled`, `last_spin_at`…) que **no estaban en ningún `ALTER` del repo**. Sin ellas, `POST /reps` devuelve **500** en una base recién creada — o sea, el esquema nunca fue reconstruible desde el repositorio.

Todo eso está absorbido. `schema.sql` pasa de levantar **31 tablas** a **45**.

**Bonus**: arreglado el seed de `/db/init` que hacía `UPDATE cosmetics SET rarity = 'epic'` — rareza que no existe en el juego (`common|rare|especial|legendary|calistenico`) y que ninguna query de cofre matchea, así que esos cosméticos quedaban huérfanos. Es el bug que mencionaba la task.

## Lo que NO cierra este PR

Cuatro tablas **no tienen `CREATE TABLE` en ningún sitio del repo** — ni aquí, ni en `/db/init`, ni en `archive/`, ni en `scripts/`. Se crearon a mano y nunca se versionaron:

- `daily_shop_items` (rotación diaria de la tienda)
- `boss_participants` (daño por usuario en el boss comunitario)
- `weekly_challenges`
- `user_skills`

Por eso `GET /shop/daily` sigue dando 500 en una BD virgen. **Cerrarlo requiere un `pg_dump --schema-only` de producción** y pegar aquí su DDL — algo que no puedo hacer desde el sandbox y que encaja mejor con la Fase 2/3 de la migración de BD. Lo dejé documentado explícitamente al final de `schema.sql` para que no se pierda. Esas tablas ya eran irreconstruibles antes de este PR, así que no es una regresión.

## Verificación: **integración local** — el test de arranque en BD limpia que pediste

Postgres 16 efímero. `createdb` vacío → arrancar el backend con `DATABASE_URL`/`JWT_SECRET` dummy → ejercitar la API con `curl`:

```
[Startup migration] schema.sql aplicado.
Server is running on port 5612
tablas: 45   (partiendo de 0)
```

| Endpoint | Antes del PR (BD virgen) | Ahora |
|---|---|---|
| `POST /auth/signup` | 200 | 200 |
| **`POST /reps`** | **500** (`column "is_crit" does not exist`) | **200** |
| **`GET /missions`** | **500** (`relation "user_missions" does not exist`) | **200** |
| **`GET /roulette/status`** | **500** | **200** |
| `GET /reps`, `/reps/stats`, `/shop/cosmetics`, `/notifications`, `/boss/active`, `/streak/status`, `/challenges`, `/social-feed/stats` | varios rotos | **200** |
| `GET /shop/daily` | 500 | **500** — la tabla huérfana de arriba |

Además:
- `schema.sql` cargado **dos veces seguidas** sobre la misma BD: **0 errores** en la segunda pasada (idempotencia real).
- **Diff de catálogo**: construí una BD sólo con `schema.sql` y otra sólo con el DDL extraído de `/db/init`, y comparé `information_schema` — el gap de tablas y columnas es ahora **vacío**, o sea que retirar el DDL de `/db/init` no pierde nada.
- **Segundo arranque limpio**: 0 errores de `does not exist` (en el primero quedan algunos de módulos que aún hacen su propio bootstrap al importarse, antes de que corra la migración; se resuelven solos en el siguiente boot y no impiden que el servidor sirva).
- `node --check` en los ficheros tocados.

No se tocó producción ni la BD real.

**Sobre el riesgo**: afecta al arranque del backend, como avisaste. La red de seguridad es que `schema.sql` es idempotente y que sobre una BD ya migrada (producción) no ejecuta ningún cambio — lo verifiqué con la doble pasada. Si la lectura del fichero fallara, se loguea y el arranque continúa, en vez de tumbar el proceso.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNEe7PaSrajFNupFZFSqL1)_